### PR TITLE
Fixed string representation of rewards

### DIFF
--- a/neurogym/core.py
+++ b/neurogym/core.py
@@ -42,10 +42,13 @@ def env_string(env):
     #         string +=\
     #             key + ' : ' + tasktools.random_number_name(dist, args) + '\n'
 
-    if env.rewards:
+    if env.rewards is not None: #if env.rewards is an array, if env.rewards will throw an error
         string += '\nReward structure \n'
-        for key, val in env.rewards.items():
-            string += key + ' : ' + str(val) + '\n'
+        try: #if the reward structure is a dictionary
+            for key, val in env.rewards.items():
+                string += key + ' : ' + str(val) + '\n'
+        except AttributeError: #otherwise just add the reward structure to the string?
+            string += str(env.rewards)
 
     # add extra info
     other_info = list(set(metadata.keys()) - set(METADATA_DEF_KEYS))


### PR DESCRIPTION
Added try statement for when reward structure is not a dict and is probably an array, as in the Bandit task. Checks to see if the rewards is not None instead of "if env.rewards" as this throws a ValueError when the attribute is an array.