### PR TITLE
Fix the one-step-mismatch problem for plotting and a bug when evaluating the models

### DIFF
--- a/neurogym/core.py
+++ b/neurogym/core.py
@@ -178,6 +178,8 @@ class TrialEnv(BaseEnv):
             trial = self._top.new_trial()
             self.performance = 0
             info['trial'] = trial
+            if self.num_tr > self.num_tr_exp:
+                done = True
         if ob == OBNOW:
             ob = self.ob[self.t_ind]
         return ob, reward, done, info

--- a/neurogym/envs/dawtwostep.py
+++ b/neurogym/envs/dawtwostep.py
@@ -94,6 +94,7 @@ class DawTwoStep(ngym.TrialEnv):
 
         ob = np.zeros((3,))
         if self.t == 0:  # at stage 1, if action==fixate, abort
+            info['gt'] = self.ground_truth
             if action == 0:
                 reward = self.rewards['abort']
                 info['new_trial'] = True
@@ -103,6 +104,7 @@ class DawTwoStep(ngym.TrialEnv):
                 reward = trial['reward'][int(state-1)]
                 self.performance = action == self.ground_truth
         elif self.t == self.dt:
+            info['gt'] = 0
             ob[0] = 1
             if action != 0:
                 reward = self.rewards['abort']

--- a/neurogym/utils/plotting.py
+++ b/neurogym/utils/plotting.py
@@ -79,9 +79,10 @@ def run_env(env, num_steps=200, num_trials=None, def_act=None, model=None):
         num_steps = 1e5  # Overwrite num_steps value
 
     trial_count = 0
+    done, _states = False, None
     for stp in range(int(num_steps)):
         if model is not None:
-            action, _states = model.predict(ob)
+            action, _states = model.predict(ob, deterministic=True, state=_states)
             if isinstance(action, float) or isinstance(action, int):
                 action = [action]
             if len(_states) > 0:
@@ -271,6 +272,9 @@ def plot_env_1dbox(
         i_ax += 1
         ax.plot(steps, rewards, 'r', label='Rewards')
         ax.set_ylabel('Reward')
+        rewards = np.array(rewards)
+        sum_rew = np.sum(rewards)
+        ax.set_title('Total reward: ' + str(np.round(sum_rew, 2)))
         ax.spines['top'].set_visible(False)
         ax.spines['right'].set_visible(False)
         if legend:
@@ -317,7 +321,7 @@ def plot_env_1dbox(
     plt.tight_layout()
     if fname:
         fname = str(fname)
-        if not (fname.endswith('.png') or fname.endswith('.svg')):
+        if not (fname.endswith('.png') or fname.endswith('.svg') or fname.endswith('.pdf')):
             fname += '.png'
         f.savefig(fname, dpi=300)
         plt.close(f)

--- a/neurogym/utils/plotting.py
+++ b/neurogym/utils/plotting.py
@@ -70,7 +70,11 @@ def run_env(env, num_steps=200, num_trials=None, def_act=None, model=None):
     perf = []
     ob = env.reset()  # TODO: not saving this first observation
     ob_cum_temp = ob
-
+    if isinstance(ob, list) or ob.shape[0] == 1:
+        ob_aux = ob[0]
+    else:
+        ob_aux = ob
+    observations.append(ob_aux.copy())
     if num_trials is not None:
         num_steps = 1e5  # Overwrite num_steps value
 
@@ -124,9 +128,8 @@ def run_env(env, num_steps=200, num_trials=None, def_act=None, model=None):
         states = states[:, 0, :]
     else:
         states = None
-
     data = {
-        'ob': np.array(observations).astype(np.float),
+        'ob': np.array(observations[:-1]).astype(np.float),
         'ob_cum': np.array(ob_cum).astype(np.float),
         'rewards': rewards,
         'actions': actions,


### PR DESCRIPTION
11/18: latest: 
1) fix a bug when evaluating the models
--------
1) In the plots, the observations at step t and the action at step t should be aligned.

2) When reaching the maximal number of trials, the current episode should be done.

3) There is a remaining one-step-mismatch problem during reset. When num_trials_before_reset is large, it is not important; however, for a sequential value learning task, num_trials_before_reset is typically small (like 100 trials for each episode), so the first trial after reset matters.