### PR TITLE
ci: turn off linkspector bot reviewer

### DIFF
--- a/.github/workflows/linkspector.yml
+++ b/.github/workflows/linkspector.yml
@@ -31,6 +31,5 @@ jobs:
       - name: Run linkspector
         uses: umbrelladocs/action-linkspector@v1
         with:
-          reporter: github-pr-review
           fail_on_error: true
           config_file: .github/settings/.linkspector.yml

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,7 @@
 {
-  "recommendations": ["esbenp.prettier-vscode", "charliermarsh.ruff"]
+  "recommendations": [
+    "esbenp.prettier-vscode",
+    "charliermarsh.ruff",
+    "foxundermoon.shell-format"
+  ]
 }


### PR DESCRIPTION
Having a bot reviewer checking the links was a non-default setting that I accidentally added in #91 . I tested it and like this broken links do not trigger a bot PR reviewer.
I also added the missing VS code extension recommendation that we found in our meeting.

closes #96 