### PR TITLE
ci: automatically deploy docs

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,25 @@
+name: Test Documentation
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  test-docs:
+    if: github.event.pull_request.draft == false
+    name: Test documentation build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Build documentation
+        run: >
+          python -m pip install .[dev]
+          mkdocs build

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -63,3 +63,23 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN_NEUROGYM }}
+
+  deploy_docs:
+    name: Deploy documentation
+    needs: upload_pypi
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: main
+      - name: Install Python
+        uses: actions/setup-python@v5.1.1
+        with:
+          python-version: "3.12"
+      - name: Install requirements
+        run: python3 -m pip install .[dev]
+      - name: Build documentation
+        run: |
+          version=$(git describe --tags --abbrev=0)
+          mike deploy -p -u $version latest

--- a/README.dev.md
+++ b/README.dev.md
@@ -76,7 +76,11 @@ To watch the changes of current doc in real time, run:
 
 ```shell
 mkdocs serve
-# or to watch src and docs directories
+```
+
+or to watch src and docs directories
+
+```shell
 mkdocs serve -w docs -w src
 ```
 
@@ -86,13 +90,25 @@ Then open your browser and go to [http://127.0.0.1:8000/](http://127.0.0.1:8000/
 
 The docs are published on GitHub pages. We use [mike](https://github.com/jimporter/mike) to deploy the docs to the `gh-pages` branch and to manage the versions of docs.
 
-For example, to deploy the version 2.0 of the docs to the `gh-pages` branch and make it the latest version, run:
+Docs are automatically deployed upon each new release to PyPi as part of our [PyPi
+release](.github/workflows/release_pypi.yml) workflow and named identically to the newest GitHub version number (i.e. `vX.Y.Z`).
+
+To manually deploy (additional) versions of the docs, run:
 
 ```shell
-mike deploy -p -u 2.0 latest
+mike deploy -p -u `<docs_version_name>`
 ```
 
-If you are not happy with the changes you can run `mike delete [version]`. All these mike operations will be recorded as git commits of branch `gh-pages`.
+Add `latest` to the end of the command above, to make this the latest default version of the docs (i.e. the landing page
+of https://neurogym.github.io/).
+
+To remove a given version of the documentation, run
+
+```shell
+mike delete <docs_version_name>
+```
+
+Note that all mike operations above will be recorded as git commits to the `gh-pages` branch.
 
 Use `mike serve` to review all versions of the site that have been committed to the `gh-pages` branch. It’s part of the `mike` tool, which manages versioned documentation for `mkdocs`. This command is best for verifying the production website as it exists in the repository.
 


### PR DESCRIPTION
this PR implements the commits in order of commits:

1. deploy documentation upon PyPi release
    - it reads the GitHub version tag to name the docs version, meaning that the `v` is included before the version number, which is different from what is written in the issue/dev readme. I think that should be ok, but I can also look into how to drop the first character (shouldn't be too hard).
2. add a workflow that checks on each PR that the documentation can still be built.
3. update dev readme regarding docs deployment.


blocked by #69