### PR TITLE
ci: fix bugs in release workflows

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,7 +1,6 @@
 [tool.bumpversion]
 current_version = "1.0.3"
 tag_prefix = "v"
-tag = true
 
 [[tool.bumpversion.files]]
 filename = "pyproject.toml"
@@ -9,16 +8,16 @@ search = 'version = "{current_version}"'
 replace = 'version = "{new_version}"'
 
 [[tool.bumpversion.files]]
-# note that the it's not possible to do 2 search/replace actions to the same file in a single entry
-filename = "CITATION.cff"
-search = "date-released= '\\d{{4}}-\\d{{2}}-\\d{{2}}'"
-replace = "date-released = '{now:%Y-%m-%d}'"
-regex = true
-
-[[tool.bumpversion.files]]
 filename = "CITATION.cff"
 search = 'version: {current_version}'
 replace = 'version: {new_version}'
+
+[[tool.bumpversion.files]]
+# note that the it's not possible to do 2 search/replace actions to the same file in a single entry
+filename = "CITATION.cff"
+search = 'date-released: "\d{{4}}-\d{{2}}-\d{{2}}"'
+replace = "date-released: \"{now:%Y-%m-%d}\""
+regex = true
 
 [[tool.bumpversion.files]]
 filename = "neurogym/__init__.py"

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -45,8 +45,12 @@ jobs:
         run: |
           which python
           python --version
-      - name: Check linting and formatting using ruff
+      - name: Install ruff
         run: |
-          python3 -m pip install ruff
-          ruff check || (echo "Please ensure you have the latest version of ruff (`ruff -V`) installed locally." && (exit 1))
-          ruff format --check || (echo "Please ensure you have the latest version of ruff (`ruff -V`) installed locally." && (exit 1))
+          python3 -m pip install pyproject-deplister
+          pyproject-deplister --extra dev --path pyproject.toml | grep ruff | sed 's/ //g' | xargs -I{} python3 -m pip install "{}"
+          echo "Installed ruff version: $(ruff -V)"
+      - name: Check linting using ruff
+        run: ruff check || (echo "Please ensure you have a matching version of ruff (`ruff -V`) installed locally." && (exit 1))
+      - name: Check formatting using ruff
+        run: ruff format --check || (echo "Please ensure you have a matching version of ruff (`ruff -V`) installed locally." && (exit 1))

--- a/.github/workflows/release_github.yml
+++ b/.github/workflows/release_github.yml
@@ -103,7 +103,7 @@ jobs:
         shell: bash
         run: |
           echo "previous-version=$(bump-my-version show current_version)" >> $GITHUB_OUTPUT
-          bump-my-version bump ${{ inputs.version_level }} --commit --tag
+          bump-my-version bump ${{ inputs.version_level }} --commit --tag -vv
           ([[ $? -gt 0 ]] && echo "bumped=false" || echo "bumped=true") >> $GITHUB_OUTPUT
           echo "current-version=$(bump-my-version show current_version)" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -76,6 +76,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
+          fetch-tags: true
       - name: Install Python
         uses: actions/setup-python@v5.1.1
         with:
@@ -85,4 +86,4 @@ jobs:
       - name: Build documentation
         run: |
           version=$(git describe --tags --abbrev=0)
-          mike deploy -p -u $version latest
+          mike deploy -p -u $version latest --allow-empty

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -86,4 +86,4 @@ jobs:
       - name: Build documentation
         run: |
           version=$(git describe --tags --abbrev=0)
-          mike deploy -p -u $version latest --allow-empty
+          mike deploy -p -u $version latest

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -58,4 +58,4 @@ keywords:
   - synthetic data
 license: Apache-2.0
 version: 1.0.3
-date-released: "2024-12-10"
+date-released: "2024-12-20"

--- a/README.dev.md
+++ b/README.dev.md
@@ -205,7 +205,7 @@ NOTE: the current token (associated to @DaniBodor) allowing to bypass branch pro
 2. Prepare the branch for the release (e.g., removing the unnecessary dev files, fix minor bugs if necessary). Do this by ensuring all tests pass `pytest -v` and that linting (`ruff check`) and formatting (`ruff format --check`) conventions are adhered to.
 3. Decide on the [version level increase](#versioning), following [semantic versioning
    conventions](https://semver.org/). Use [bump-my-version](https://github.com/callowayproject/bump-my-version):
-   `bump-my-version bump <level>` to update the version throughout the package.
+   `bump-my-version bump <level> --commit --tag -vv` to update the version throughout the package.
 4. Merge the release branch into `main` and `dev`.
 5. On the [Releases page](https://github.com/neurogym/neurogym/releases):
    1. Click "Draft a new release"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dev = [
     "pytest-cov",
     "coverage [toml]",
     # code style
-    "ruff >= 0.8.0",
+    "ruff==0.8.*",
     "mypy",
     # docs
     "mkdocs",


### PR DESCRIPTION
- update bump version settings to correctly update the date
    - I've tested it locally and it works as expected.
- ensure that docs deployment reads the latest version tag, so that mike knows the version number
  - the solution should be sufficient, but I have not tested this (not sure if there is any easy way to test it). In [eitprocessing](https://github.com/EIT-ALIVE/eitprocessing/blob/main/.github/workflows/test_build_documentation.yml), we instead check out the entire depth of the repo using `fetch-depth: 0`, and there it works fine (using mkdocs to deploy rather than mike, but the issue seemed to be in fetching the tag and not in the actual deployment).

EDITED:
- ensure that ruff version used by CI is same as specified in pyproject.toml
  - this was a late addition to the PR


fix: #112 
fix: #111 
