### PR TITLE
docs: installation instructions

### DIFF
--- a/.github/workflows/linkspector.yml
+++ b/.github/workflows/linkspector.yml
@@ -27,9 +27,12 @@ jobs:
     name: linkspector
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Resolve "No usable sandbox" error
+        run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
       - name: Run linkspector
         uses: umbrelladocs/action-linkspector@v1
         with:
-          fail_on_error: true
+          level: any
           config_file: .github/settings/.linkspector.yml

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ conda activate neurogym
 
 #### Step 2: Install neurogym
 
-Then install neurogym as follows:
+Then install the latest version of `neurogym` as follows:
 
 ```bash
 pip install neurogym

--- a/README.md
+++ b/README.md
@@ -29,17 +29,30 @@ Please see our extended project [documentation](https://neurogym.github.io/neuro
 
 ### Installation
 
+#### Step 1: Create a virtual environment
+
 Create and activate a virtual environment to install the current package, e.g. using
 [conda](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html) (please refer to their
 site for questions about creating the environment):
 
 ```bash
 conda activate # ensures you are in the base environment
-conda create -n neurogym python=3.11
+conda create -n neurogym python=3.11 -y
 conda activate neurogym
 ```
 
+#### Step 2: Install neurogym
+
 Then install neurogym as follows:
+
+```bash
+pip install neurogym
+```
+
+##### Step 2b: Install editable package
+
+Alternatively, get the latest updates by cloning the repo and installing the editable version of neurogym, by replacing
+step 2 above by:
 
 ```bash
 git clone https://github.com/neurogym/neurogym.git
@@ -47,7 +60,9 @@ cd neurogym
 pip install -e .
 ```
 
-#### Psychopy installation
+#### Step 3 (Optional): Psychopy installation
+
+**NOTE**: psycohopy installation is currently not working
 
 If you need psychopy for your project, additionally run
 

--- a/docs/examples/demo.ipynb
+++ b/docs/examples/demo.ipynb
@@ -7,7 +7,7 @@
     "id": "view-in-github"
    },
    "source": [
-    "<a href=\"https://colab.research.google.com/github/gyyang/neurogym/blob/master/examples/demo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/gyyang/neurogym/blob/master/examples/demo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n"
    ]
   },
   {
@@ -18,7 +18,7 @@
     "id": "4zW6CU8F69Zp"
    },
    "source": [
-    "## Exploring NeuroGym tasks"
+    "## Exploring NeuroGym tasks\n"
    ]
   },
   {
@@ -31,7 +31,7 @@
    "source": [
     "NeuroGym is a comprehensive toolkit that allows training any network model on many established neuroscience tasks using Reinforcement Learning techniques. It includes working memory tasks, value-based decision tasks and context-dependent perceptual categorization tasks.\n",
     "\n",
-    "In this notebook we first show how to install the relevant toolbox. \n",
+    "In this notebook we first show how to install the relevant toolbox.\n",
     "\n",
     "We then show how to access the available tasks and their relevant information.\n",
     "\n",
@@ -47,7 +47,9 @@
     "id": "k3YKMoHkR2xL"
    },
    "source": [
-    "### Installation on google colab"
+    "### Installation on google colab\n",
+    "\n",
+    "Uncomment and execute cell below if running on google colab.\n"
    ]
   },
   {
@@ -73,14 +75,14 @@
     }
    ],
    "source": [
-    "# Install gymnasium\n",
-    "! pip install gymnasium\n",
-    "# Install neurogym\n",
-    "! git clone https://github.com/gyyang/neurogym.git\n",
-    "%cd neurogym/\n",
-    "! pip install -e .\n",
-    "# Install stable-baselines3\n",
-    "! pip install stable-baselines3"
+    "# # Install gymnasium\n",
+    "# ! pip install gymnasium\n",
+    "# # Install neurogym\n",
+    "# ! git clone https://github.com/neurogym/neurogym.git\n",
+    "# %cd neurogym/\n",
+    "# ! pip install -e .\n",
+    "# # Install stable-baselines3\n",
+    "# ! pip install stable-baselines3"
    ]
   },
   {
@@ -90,7 +92,7 @@
     "id": "ZllQKETBVXNM"
    },
    "source": [
-    "### Explore tasks"
+    "### Explore tasks\n"
    ]
   },
   {
@@ -160,7 +162,7 @@
     "id": "jzF5leN1R2xU"
    },
    "source": [
-    "### Visualize a single task"
+    "### Visualize a single task\n"
    ]
   },
   {
@@ -215,7 +217,7 @@
     "id": "h5BdRE6vVjeS"
    },
    "source": [
-    "### Explore wrappers"
+    "### Explore wrappers\n"
    ]
   },
   {
@@ -287,7 +289,7 @@
     "id": "OCFMPbzX38Wj"
    },
    "source": [
-    "### Train a network"
+    "### Train a network\n"
    ]
   },
   {
@@ -389,7 +391,7 @@
     "id": "svUQlptJAVv9"
    },
    "source": [
-    "### Visualize results"
+    "### Visualize results\n"
    ]
   },
   {

--- a/docs/examples/example_neurogym_keras.ipynb
+++ b/docs/examples/example_neurogym_keras.ipynb
@@ -35,7 +35,9 @@
     "id": "DS1FhYPG38WO"
    },
    "source": [
-    "### Installation when used on Google Colab\n"
+    "### Installation on google colab\n",
+    "\n",
+    "Uncomment and execute cell below if running on google colab.\n"
    ]
   },
   {
@@ -52,13 +54,13 @@
    },
    "outputs": [],
    "source": [
-    "%tensorflow_version 1.x\n",
-    "# Install gymnasium\n",
-    "! pip install gymnasium\n",
-    "# Install neurogym\n",
-    "! git clone https://github.com/gyyang/neurogym.git\n",
-    "%cd neurogym/\n",
-    "! pip install -e ."
+    "# %tensorflow_version 1.x\n",
+    "# # Install gymnasium\n",
+    "# ! pip install gymnasium\n",
+    "# # Install neurogym\n",
+    "# ! git clone https://github.com/neurogym/neurogym.git\n",
+    "# %cd neurogym/\n",
+    "# ! pip install -e ."
    ]
   },
   {

--- a/docs/examples/example_neurogym_pytorch.ipynb
+++ b/docs/examples/example_neurogym_pytorch.ipynb
@@ -8,14 +8,16 @@
     "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/neurogym/neurogym/blob/master/examples/example_neurogym_pytorch.ipynb)\n",
     "\n",
-    "Pytorch-based example code for training a RNN on a perceptual decision-making task."
+    "Pytorch-based example code for training a RNN on a perceptual decision-making task.\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Installation when used on Google Colab"
+    "### Installation on google colab\n",
+    "\n",
+    "Uncomment and execute cell below if running on google colab.\n"
    ]
   },
   {
@@ -24,19 +26,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Install gymnasium\n",
-    "! pip install gymnasium\n",
-    "# Install neurogym\n",
-    "! git clone https://github.com/gyyang/neurogym.git\n",
-    "%cd neurogym/\n",
-    "! pip install -e ."
+    "# # Install gymnasium\n",
+    "# ! pip install gymnasium\n",
+    "# # Install neurogym\n",
+    "# ! git clone https://github.com/neurogym/neurogym.git\n",
+    "# %cd neurogym/\n",
+    "# ! pip install -e ."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Dataset"
+    "### Dataset\n"
    ]
   },
   {
@@ -68,7 +70,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Network and Training"
+    "### Network and Training\n"
    ]
   },
   {
@@ -140,7 +142,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Analysis"
+    "### Analysis\n"
    ]
   },
   {

--- a/docs/examples/example_neurogym_rl.ipynb
+++ b/docs/examples/example_neurogym_rl.ipynb
@@ -8,7 +8,7 @@
     "id": "4zW6CU8F69Zp"
    },
    "source": [
-    "## Reinforcement learning example with stable-baselines3"
+    "## Reinforcement learning example with stable-baselines3\n"
    ]
   },
   {
@@ -21,7 +21,7 @@
    "source": [
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/neurogym/neurogym/blob/master/examples/example_neurogym_rl.ipynb)\n",
     "\n",
-    "NeuroGym is a toolkit that allows training any network model on many established neuroscience tasks techniques such as standard Supervised  Learning or Reinforcement Learning (RL). In this notebook we will use RL to train an LSTM network on the classical Random Dots Motion (RDM) task (Britten et al. 1992).\n",
+    "NeuroGym is a toolkit that allows training any network model on many established neuroscience tasks techniques such as standard Supervised Learning or Reinforcement Learning (RL). In this notebook we will use RL to train an LSTM network on the classical Random Dots Motion (RDM) task (Britten et al. 1992).\n",
     "\n",
     "We first show how to install the relevant toolboxes. We then show how build the task of interest (in the example the RDM task), wrapp it with the pass-reward wrapper in one line and visualize the structure of the final task. Finally we train an LSTM network on the task using the A2C algorithm [Mnih et al. 2016](https://arxiv.org/abs/1602.01783) implemented in the [stable-baselines3](https://stable-baselines3.readthedocs.io/en/master/) toolbox, and plot the results.\n",
     "\n",
@@ -35,8 +35,9 @@
     "id": "k3YKMoHkR2xL"
    },
    "source": [
-    "### Installation\n",
-    "(only for running in Google Colab)"
+    "### Installation on google colab\n",
+    "\n",
+    "Uncomment and execute cell below if running on google colab.\n"
    ]
   },
   {
@@ -108,15 +109,15 @@
     }
    ],
    "source": [
-    "%tensorflow_version 1.x\n",
-    "# Install gymnasium\n",
-    "! pip install gymnasium\n",
-    "# Install neurogym\n",
-    "! git clone https://github.com/gyyang/neurogym.git\n",
-    "%cd neurogym/\n",
-    "! pip install -e .\n",
-    "# Install stable-baselines3\n",
-    "! pip install stable-baselines3"
+    "# %tensorflow_version 1.x\n",
+    "# # Install gymnasium\n",
+    "# ! pip install gymnasium\n",
+    "# # Install neurogym\n",
+    "# ! git clone https://github.com/neurogym/neurogym.git\n",
+    "# %cd neurogym/\n",
+    "# ! pip install -e .\n",
+    "# # Install stable-baselines3\n",
+    "# ! pip install stable-baselines3"
    ]
   },
   {
@@ -126,7 +127,7 @@
     "id": "jzF5leN1R2xU"
    },
    "source": [
-    "### Task"
+    "### Task\n"
    ]
   },
   {
@@ -136,13 +137,12 @@
     "id": "1vb3YFfIoOA4"
    },
    "source": [
-    "here we build the Random Dots Motion task, specifying the duration of each trial period (fixation, stimulus, decision) and wrapp it with the pass-reward wrapper which appends the previous reward to the observation. We then plot the structure of the task in a figure that shows: \n",
-    "1. The observations received by the agent (top panel). \n",
+    "here we build the Random Dots Motion task, specifying the duration of each trial period (fixation, stimulus, decision) and wrapp it with the pass-reward wrapper which appends the previous reward to the observation. We then plot the structure of the task in a figure that shows:\n",
+    "\n",
+    "1. The observations received by the agent (top panel).\n",
     "2. The actions taken by a random agent and the correct action at each timestep (second panel).\n",
     "3. The rewards provided by the environment at each timestep (third panel).\n",
-    "4. The performance of the agent at each trial (bottom panel).\n",
-    "\n",
-    "\n"
+    "4. The performance of the agent at each trial (bottom panel).\n"
    ]
   },
   {
@@ -241,7 +241,7 @@
     "id": "OCFMPbzX38Wj"
    },
    "source": [
-    "### Train a network"
+    "### Train a network\n"
    ]
   },
   {
@@ -502,7 +502,7 @@
     "id": "svUQlptJAVv9"
    },
    "source": [
-    "### Visualize results"
+    "### Visualize results\n"
    ]
   },
   {

--- a/docs/examples/understanding_neurogym_task.ipynb
+++ b/docs/examples/understanding_neurogym_task.ipynb
@@ -19,9 +19,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Installation\n",
+    "### Installation on google colab\n",
     "\n",
-    "Only needed if running in Google colab. Uncomment to run.\n"
+    "Uncomment and execute cell below if running on google colab.\n"
    ]
   },
   {
@@ -36,7 +36,7 @@
     "# ! pip install gymnasium\n",
     "\n",
     "# # Install neurogym\n",
-    "# ! git clone https://github.com/gyyang/neurogym.git\n",
+    "# ! git clone https://github.com/neurogym/neurogym.git\n",
     "# %cd neurogym/\n",
     "# ! pip install -e ."
    ]
@@ -652,7 +652,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "ngym",
    "language": "python",
    "name": "python3"
   },
@@ -666,7 +666,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.11.10"
   }
  },
  "nbformat": 4,

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,16 +1,29 @@
 # Installation
 
+## Step 1: Create a virtual environment
+
 Create and activate a virtual environment to install the current package, e.g. using
 [conda](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html) (please refer to their
 site for questions about creating the environment):
 
 ```bash
 conda activate # ensures you are in the base environment
-conda create -n neurogym python=3.11
+conda create -n neurogym python=3.11 -y
 conda activate neurogym
 ```
 
+## Step 2: Install neurogym
+
 Then install neurogym as follows:
+
+```bash
+pip install neurogym
+```
+
+### Step 2b: Install editable package
+
+Alternatively, get the latest updates by cloning the repo and installing the editable version of neurogym, by replacing
+step 2 above by:
 
 ```bash
 git clone https://github.com/neurogym/neurogym.git
@@ -18,7 +31,9 @@ cd neurogym
 pip install -e .
 ```
 
-## Psychopy installation
+## Step 3 (Optional): Psychopy installation
+
+**NOTE**: psycohopy installation is currently not working
 
 If you need psychopy for your project, additionally run
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -14,7 +14,7 @@ conda activate neurogym
 
 ## Step 2: Install neurogym
 
-Then install neurogym as follows:
+Then install the latest version of `neurogym` as follows:
 
 ```bash
 pip install neurogym

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 # see documentation, e.g.
-# - https://packaging.python.org/en/latest/specifications/declaring-project-metadata/#declaring-project-metadata
+# - https://packaging.python.org/en/latest/specifications/pyproject-toml/
 # - https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html
-# - https://www.python.org/dev/peps/pep-0621/
 
 [build-system]
 requires = ["setuptools>=64.0.0", "setuptools-scm", "wheel"]
@@ -38,7 +37,7 @@ keywords = [
     "reinforcement learning",
     "synthetic data",
 ]
-license = { file = "LICENSE" }
+license = { text = "Apache-2.0 License" }
 name = "neurogym"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"


### PR DESCRIPTION
- Updated the installation instructions on readme and in the docs.
    - Note that psychopy installation crashes, even in a fresh environment (I tried python 3.10 and 3.11). For now, I left the instructions with a note that it doesn't work. Should we instead remove psychopy from the package altogether and instead add a note to the envs that uses it (or even remove those envs)? I created a new [issue](#125) to look into this.
- I haven't touched the PyPi related issues flagged in #113, see [comments](https://github.com/neurogym/neurogym/issues/113#issuecomment-2589570566) I left there.
    - Please let me know if I misunderstood the issue or if you would still like me to make changes to this
- Additional minor improvement: changed the way the license field is displayed on PyPi

closes: #113 