### PR TITLE
ci: fix sonarcloud workflow

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -26,6 +26,7 @@ on:
       - "**.ipynb"
       - "**.cff"
       - "**.png"
+
 jobs:
   sonarcloud:
     if: github.event.pull_request.draft == false
@@ -51,7 +52,7 @@ jobs:
       - name: Correct coverage paths
         run: sed -i "s+$PWD/++g" coverage.xml
       - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@v4.1.0
+        uses: SonarSource/sonarqube-scan-action@v5.1.0
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{secrets.SONAR_TOKEN }}


### PR DESCRIPTION
The sonarcloud workflow was failing due to faulty settings (see e.g. https://github.com/neurogym/neurogym/actions/runs/14081162132/job/39434228660?pr=155).

It turned out that updating the sonarqube action to v5 solves the probem.

close #157 