### PR TITLE
refactor: registration module

### DIFF
--- a/docs/examples/demo.ipynb
+++ b/docs/examples/demo.ipynb
@@ -102,11 +102,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from neurogym.envs.registration import ALL_ENVS, all_envs\n",
+    "from neurogym.envs.registration import ALL_NATIVE_ENVS, all_envs\n",
     "from pprint import pprint\n",
     "identicals = 0\n",
     "\n",
-    "for env_v, location in ALL_ENVS.items():\n",
+    "for env_v, location in ALL_NATIVE_ENVS.items():\n",
     "    if identicals == 0:\n",
     "        example = (env_v, location)\n",
     "    part1 = env_v[:-3]\n",

--- a/docs/examples/demo.ipynb
+++ b/docs/examples/demo.ipynb
@@ -92,8 +92,32 @@
     "import gymnasium as gym\n",
     "import neurogym as ngym\n",
     "from neurogym.utils import info, plotting\n",
-    "warnings.filterwarnings('ignore')\n",
+    "# warnings.filterwarnings('ignore')\n",
     "info.all_tasks()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from neurogym.envs.registration import ALL_ENVS, all_envs\n",
+    "from pprint import pprint\n",
+    "identicals = 0\n",
+    "\n",
+    "for env_v, location in ALL_ENVS.items():\n",
+    "    if identicals == 0:\n",
+    "        example = (env_v, location)\n",
+    "    part1 = env_v[:-3]\n",
+    "    part2 = location[-len(part1):]\n",
+    "\n",
+    "    if part1==part2:\n",
+    "        identicals += 1\n",
+    "    else:\n",
+    "        print(env_v, location)\n",
+    "print(f\"Identical envs: {identicals}\")\n",
+    "print(f\"for example:{example}\")"
    ]
   },
   {
@@ -120,7 +144,7 @@
    },
    "outputs": [],
    "source": [
-    "task = 'GoNogo-v0'\n",
+    "task = 'GoNogo'\n",
     "env = gym.make(task)\n",
     "print(env)\n",
     "# plotting.plot_env(env, num_steps=300, def_act=0, ob_traces=['Fixation cue', 'Stim1', 'Stim2'], fig_kwargs={'figsize': (12, 12)})\n",
@@ -131,6 +155,15 @@
     "    ob_traces=['Fixation cue', 'NoGo', 'Go'],\n",
     "    # fig_kwargs={'figsize': (12, 12)}\n",
     "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "env.spec.id"
    ]
   },
   {
@@ -281,7 +314,7 @@
   },
   "hide_input": false,
   "kernelspec": {
-   "display_name": "testenv",
+   "display_name": "ngym",
    "language": "python",
    "name": "python3"
   },
@@ -295,7 +328,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.11"
+   "version": "3.11.10"
   },
   "toc": {
    "base_numbering": 1,

--- a/neurogym/envs/registration.py
+++ b/neurogym/envs/registration.py
@@ -3,6 +3,7 @@ from inspect import getmembers, isclass, isfunction
 from pathlib import Path
 
 import gymnasium as gym
+from rapidfuzz.distance import Levenshtein
 
 from neurogym.envs.collections import get_collection
 
@@ -194,39 +195,6 @@ def all_tags():
     ]
 
 
-def _distance(s0, s1):
-    # Copyright (c) 2018 luozhouyang
-    if s0 is None:
-        msg = "Argument s0 is NoneType."
-        raise TypeError(msg)
-    if s1 is None:
-        msg = "Argument s1 is NoneType."
-        raise TypeError(msg)
-    if s0 == s1:
-        return 0.0
-    if len(s0) == 0:
-        return len(s1)
-    if len(s1) == 0:
-        return len(s0)
-
-    v0 = [0] * (len(s1) + 1)
-    v1 = [0] * (len(s1) + 1)
-
-    for i in range(len(v0)):
-        v0[i] = i
-
-    for i in range(len(s0)):
-        v1[0] = i + 1
-        for j in range(len(s1)):
-            cost = 1
-            if s0[i] == s1[j]:
-                cost = 0
-            v1[j + 1] = min(v1[j] + 1, v0[j + 1] + 1, v0[j] + cost)
-        v0, v1 = v1, v0
-
-    return v0[len(s1)]
-
-
 def make(id_, **kwargs):
     try:
         # built in env_checker raises warnings or errors when ob not in observation_space
@@ -239,7 +207,7 @@ def make(id_, **kwargs):
         else:
             all_ids = [env.id for env in gym.envs.registry.values()]
 
-        dists = [_distance(id_, env_id) for env_id in all_ids]
+        dists = [Levenshtein.distance(id_, env_id) for env_id in all_ids]
         # Python argsort
         sort_inds = sorted(range(len(dists)), key=dists.__getitem__)
         env_guesses = [all_ids[sort_inds[i]] for i in range(5)]

--- a/neurogym/envs/registration.py
+++ b/neurogym/envs/registration.py
@@ -3,7 +3,6 @@ from inspect import getmembers, isclass, isfunction
 from pathlib import Path
 
 import gymnasium as gym
-from packaging import version
 
 from neurogym.envs.collections import get_collection
 
@@ -230,11 +229,8 @@ def _distance(s0, s1):
 
 def make(id_, **kwargs):
     try:
-        # TODO: disable gym 0.24 env_checker for now (raises warnings, even errors when ob not in observation_space)
-        # FIXME: is this still relevant for gymnasium?
-        if version.parse(gym.__version__) >= version.parse("0.24.0"):
-            return gym.make(id_, disable_env_checker=True, **kwargs)
-        return gym.make(id_, **kwargs)
+        # built in env_checker raises warnings or errors when ob not in observation_space
+        return gym.make(id_, disable_env_checker=True, **kwargs)
 
     except gym.error.UnregisteredEnv as e:
         # backward compatibility with old versions of gym

--- a/neurogym/envs/registration.py
+++ b/neurogym/envs/registration.py
@@ -9,22 +9,28 @@ from neurogym.envs.collections import get_collection
 
 
 def _get_envs(
+    env_names: list[str],
     foldername: str | None = None,
     env_prefix: str | None = None,
-    allow_list: list[str] | None = None,
 ) -> dict[str, str]:
-    """A helper function to get all environments in a folder.
+    """A helper function to discover and register environments from a specified folder.
+
+    This function scans Python files in the specified folder, imports them, and registers
+    environments whose names match the provided `env_names` list.
 
     Example usage:
-        _get_envs(foldername=None, env_prefix=None)
-        _get_envs(foldername='contrib', env_prefix='contrib')
-
-    The results still need to be manually cleaned up, so this is just a helper
+        _get_envs(env_names=NATIVE_ALLOW_LIST, foldername=None, env_prefix=None)
+        _get_envs(env_names=CONTRIB_ALLOW_LIST, foldername='contrib', env_prefix='contrib')
 
     Args:
-        foldername: If str, in the form of contrib, etc.
-        env_prefix: add this prefix to all env ids
-        allow_list: list of allowed env name, for manual curation
+        env_names: A list of allowed environment names for manual curation.
+        foldername: A string specifying the subfolder within `neurogym.envs` to search for
+            environment files. If `None`, the function searches in the root folder of
+            `neurogym.envs`. For example:
+                - foldername=None: Searches in `neurogym/envs/`.
+                - foldername="contrib": Searches in `neurogym/envs/contrib/`.
+        env_prefix: A string to add as a prefix to all environment IDs. If provided, it
+            ensures that the registered environment IDs are namespaced appropriately.
 
     Returns:
         A dictionary mapping environment IDs to their entry points.
@@ -33,9 +39,6 @@ def _get_envs(
         env_prefix = ""
     elif env_prefix[-1] != ".":
         env_prefix += "."
-
-    if allow_list is None:
-        allow_list = []
 
     # Root path of neurogym.envs folder
     env_root = Path(__file__).resolve().parent
@@ -56,7 +59,7 @@ def _get_envs(
         lib = lib_root + filename
         module = importlib.import_module(lib)
         for name, _val in getmembers(module):
-            if name in allow_list:
+            if name in env_names:
                 env_dict[f"{env_prefix}{name}-v0"] = f"{lib}:{name}"
 
     return env_dict

--- a/neurogym/envs/registration.py
+++ b/neurogym/envs/registration.py
@@ -8,7 +8,11 @@ from rapidfuzz import process
 from neurogym.envs.collections import get_collection
 
 
-def _get_envs(foldername=None, env_prefix=None, allow_list=None):
+def _get_envs(
+    foldername: str | None = None,
+    env_prefix: str | None = None,
+    allow_list: list[str] | None = None,
+) -> dict[str, str]:
     """A helper function to get all environments in a folder.
 
     Example usage:
@@ -18,9 +22,12 @@ def _get_envs(foldername=None, env_prefix=None, allow_list=None):
     The results still need to be manually cleaned up, so this is just a helper
 
     Args:
-        foldername: str or None. If str, in the form of contrib, etc.
-        env_prefix: str or None, if not None, add this prefix to all env ids
+        foldername: If str, in the form of contrib, etc.
+        env_prefix: add this prefix to all env ids
         allow_list: list of allowed env name, for manual curation
+
+    Returns:
+        A dictionary mapping environment IDs to their entry points.
     """
     if env_prefix is None:
         env_prefix = ""
@@ -44,7 +51,7 @@ def _get_envs(foldername=None, env_prefix=None, allow_list=None):
     filenames = [f.name[:-3] for f in files]  # remove .py suffix
     filenames = sorted(filenames)
 
-    env_dict = {}
+    env_dict: dict[str, str] = {}
     for filename in filenames:
         lib = lib_root + filename
         module = importlib.import_module(lib)
@@ -121,7 +128,7 @@ ALL_CONTRIB_ENVS = _get_envs(
 
 
 # Automatically register all tasks in collections
-def _get_collection_envs():
+def _get_collection_envs() -> dict[str, str]:
     """Register collection tasks in collections folder.
 
     Each environment is named collection_name.env_name-v0
@@ -148,7 +155,12 @@ ALL_ENVS = {**ALL_NATIVE_ENVS, **ALL_PSYCHOPY_ENVS, **ALL_CONTRIB_ENVS}
 ALL_EXTENDED_ENVS = {**ALL_ENVS, **ALL_COLLECTIONS_ENVS}
 
 
-def all_envs(tag=None, psychopy=False, contrib=False, collections=False):
+def all_envs(
+    tag: str | None = None,
+    psychopy: bool = False,
+    contrib: bool = False,
+    collections: bool = False,
+) -> list[str]:
     """Return a list of all envs in neurogym."""
     envs = ALL_NATIVE_ENVS.copy()
     if psychopy:
@@ -164,7 +176,7 @@ def all_envs(tag=None, psychopy=False, contrib=False, collections=False):
         msg = f"{type(tag)=} must be a string."
         raise TypeError(msg)
 
-    new_env_list = []
+    new_env_list: list[str] = []
     for env in env_list:
         from_, class_ = envs[env].split(":")
         imported = getattr(__import__(from_, fromlist=[class_]), class_)
@@ -268,7 +280,7 @@ else:
     _all_gym_envs = [env.id for env in gym.envs.registry.values()]
 
 
-def register(id_, **kwargs) -> None:
+def register(id_: str, **kwargs) -> None:
     if id_ not in _all_gym_envs:
         gym.envs.registration.register(id=id_, **kwargs)
 

--- a/neurogym/envs/registration.py
+++ b/neurogym/envs/registration.py
@@ -7,6 +7,60 @@ from rapidfuzz import process
 
 from neurogym.envs.collections import get_collection
 
+NATIVE_ENVS = [
+    "AntiReach",
+    "Bandit",
+    "ContextDecisionMaking",
+    "DawTwoStep",
+    "DelayComparison",
+    "DelayMatchCategory",
+    "DelayMatchSample",
+    "DelayMatchSampleDistractor1D",
+    "DelayPairedAssociation",
+    # 'Detection',  # TODO: Temporary removing until bug fixed # noqa: ERA001
+    "DualDelayMatchSample",
+    "EconomicDecisionMaking",
+    "GoNogo",
+    "HierarchicalReasoning",
+    "IntervalDiscrimination",
+    "MotorTiming",
+    "MultiSensoryIntegration",
+    "Null",
+    "OneTwoThreeGo",
+    "PerceptualDecisionMaking",
+    "PerceptualDecisionMakingDelayResponse",
+    "PostDecisionWager",
+    "ProbabilisticReasoning",
+    "PulseDecisionMaking",
+    "Reaching1D",
+    "Reaching1DWithSelfDistraction",
+    "ReachingDelayResponse",
+    "ReadySetGo",
+    # "SpatialSuppressMotion",  # noqa: ERA001
+    # TODO: raises ModuleNotFound error since requires scipy, which is not in the requirements of neurogym.
+    # FIXME: I have added scipy to requirements (for other reason), does this mean SpatialSuppressMotion is valid?
+    # "ToneDetection",  # TODO: Temporary removing until bug fixed # noqa: ERA001
+]
+
+_PSYCHOPY_PREFIX = "neurogym.envs.psychopy."
+PSYCHOPY_ENVS = [
+    "RandomDotMotion",
+    "VisualSearch",
+    "SpatialSuppressMotion",  # NOTE: this is different from the SpatialSuppressMotion native env. Consider renaming.
+]
+
+_CONTRIB_NAME_PREFIX = "contrib."
+_CONTRIB_PREFIX = "neurogym.envs.contrib."
+CONTRIB_ENVS: list[str] = [  # FIXME: why are these commented out? NOTE: mypy requires type hint for empty list
+    # "AngleReproduction",
+    # "CVLearning",
+    # "ChangingEnvironment",
+    # "IBL",
+    # "MatchingPenny",
+    # "MemoryRecall",
+    # "Pneumostomeopening",
+]
+
 
 def _get_envs(
     env_names: list[str],
@@ -65,71 +119,6 @@ def _get_envs(
     return env_dict
 
 
-NATIVE_ALLOW_LIST = [
-    "AntiReach",
-    "Bandit",
-    "ContextDecisionMaking",
-    "DawTwoStep",
-    "DelayComparison",
-    "DelayMatchCategory",
-    "DelayMatchSample",
-    "DelayMatchSampleDistractor1D",
-    "DelayPairedAssociation",
-    # 'Detection',  # TODO: Temporary removing until bug fixed # noqa: ERA001
-    "DualDelayMatchSample",
-    "EconomicDecisionMaking",
-    "GoNogo",
-    "HierarchicalReasoning",
-    "IntervalDiscrimination",
-    "MotorTiming",
-    "MultiSensoryIntegration",
-    "Null",
-    "OneTwoThreeGo",
-    "PerceptualDecisionMaking",
-    "PerceptualDecisionMakingDelayResponse",
-    "PostDecisionWager",
-    "ProbabilisticReasoning",
-    "PulseDecisionMaking",
-    "Reaching1D",
-    "Reaching1DWithSelfDistraction",
-    "ReachingDelayResponse",
-    "ReadySetGo",
-    # 'SpatialSuppressMotion',   # noqa: ERA001
-    # TODO: raises ModuleNotFound error since requires scipy, which is not in the requirements of neurogym.
-    # FIXME: I have added scipy to requirements (for other reason), does this mean SpatialSuppressMotion is valid?
-    # 'ToneDetection'  # TODO: Temporary removing until bug fixed # noqa: ERA001
-]
-ALL_NATIVE_ENVS = _get_envs(
-    foldername=None,
-    env_prefix=None,
-    allow_list=NATIVE_ALLOW_LIST,
-)
-
-_psychopy_prefix = "neurogym.envs.psychopy."
-ALL_PSYCHOPY_ENVS = {
-    "psychopy.RandomDotMotion-v0": _psychopy_prefix + "perceptualdecisionmaking:RandomDotMotion",
-    "psychopy.VisualSearch-v0": _psychopy_prefix + "visualsearch:VisualSearch",
-    "psychopy.SpatialSuppressMotion-v0": _psychopy_prefix + "spatialsuppressmotion:SpatialSuppressMotion",
-}
-
-_contrib_name_prefix = "contrib."
-_contrib_prefix = "neurogym.envs.contrib."
-CONTRIB_ALLOW_LIST: list = [
-    # 'AngleReproduction',
-    # 'CVLearning',
-    # 'ChangingEnvironment',
-    # 'IBL',
-    # 'MatchingPenny',
-    # 'MemoryRecall',
-    # 'Pneumostomeopening'
-]
-ALL_CONTRIB_ENVS = _get_envs(
-    foldername="contrib",
-    env_prefix="contrib",
-    allow_list=CONTRIB_ALLOW_LIST,
-)
-
-
 # Automatically register all tasks in collections
 def _get_collection_envs() -> dict[str, str]:
     """Register collection tasks in collections folder.
@@ -151,10 +140,18 @@ def _get_collection_envs() -> dict[str, str]:
     return derived_envs
 
 
+ALL_NATIVE_ENVS = _get_envs(NATIVE_ENVS)
+ALL_CONTRIB_ENVS = _get_envs(CONTRIB_ENVS, foldername="contrib", env_prefix="contrib")
+
+# FIXME: this feels like it should be done via _get_envs, as above
+# but RandomDotMotion has a slightly different form. Is that intentional?
+ALL_PSYCHOPY_ENVS = {
+    "psychopy.RandomDotMotion-v0": f"{_PSYCHOPY_PREFIX}perceptualdecisionmaking:RandomDotMotion",
+    "psychopy.VisualSearch-v0": f"{_PSYCHOPY_PREFIX}visualsearch:VisualSearch",
+    "psychopy.SpatialSuppressMotion-v0": f"{_PSYCHOPY_PREFIX}spatialsuppressmotion:SpatialSuppressMotion",
+}
 ALL_COLLECTIONS_ENVS = _get_collection_envs()
-
 ALL_ENVS = {**ALL_NATIVE_ENVS, **ALL_PSYCHOPY_ENVS, **ALL_CONTRIB_ENVS}
-
 ALL_EXTENDED_ENVS = {**ALL_ENVS, **ALL_COLLECTIONS_ENVS}
 
 

--- a/neurogym/envs/registration.py
+++ b/neurogym/envs/registration.py
@@ -274,13 +274,13 @@ def _get_closest_matches(
 
 
 # backward compatibility with old versions of gym
-if hasattr(gym.envs.registry, "all"):
-    _all_gym_envs = [env.id for env in gym.envs.registry.all()]
-else:
-    _all_gym_envs = [env.id for env in gym.envs.registry.values()]
-
-
+# FIXME: check if backward compatibility is still required
 def register(id_: str, **kwargs) -> None:
+    if hasattr(gym.envs.registry, "all"):
+        _all_gym_envs = [env.id for env in gym.envs.registry.all()]
+    else:
+        _all_gym_envs = [env.id for env in gym.envs.registry.values()]
+
     if id_ not in _all_gym_envs:
         gym.envs.registration.register(id=id_, **kwargs)
 

--- a/neurogym/envs/registration.py
+++ b/neurogym/envs/registration.py
@@ -195,7 +195,23 @@ def all_tags():
     ]
 
 
-def make(id_, **kwargs):
+def make(id_: str, **kwargs) -> gym.Env:
+    """Creates an environment previously registered with :meth:`ngym.register`.
+
+    This function attempts to create an environment using the given `id_`. If the environment
+    is not registered, it raises an error and suggests the closest matching environment IDs.
+
+    Args:
+        id_: A string representing the environment ID.
+        kwargs: Additional arguments to pass to the environment constructor.
+
+    Returns:
+        An instance of the environment.
+
+    Raises:
+        gym.error.UnregisteredEnv: If the `id_` doesn't exist in the Neurogym's registry. The error
+            message will include suggestions for the closest matching environment IDs.
+    """
     try:
         # built in env_checker raises warnings or errors when ob not in observation_space
         return gym.make(id_, disable_env_checker=True, **kwargs)

--- a/neurogym/utils/info.py
+++ b/neurogym/utils/info.py
@@ -4,12 +4,12 @@ import inspect
 
 import neurogym as ngym
 from neurogym.core import METADATA_DEF_KEYS, env_string
-from neurogym.envs.registration import ALL_ENVS, all_envs
+from neurogym.envs.registration import ALL_NATIVE_ENVS, all_envs
 from neurogym.wrappers import ALL_WRAPPERS
 
 
 def all_tasks() -> None:
-    for task in sorted(ALL_ENVS):
+    for task in sorted(ALL_NATIVE_ENVS):
         print(task)
 
 
@@ -29,7 +29,7 @@ def info(env=None, show_code=False):
     # show source code
     if show_code:
         string += """\n#### Source code #### \n\n"""
-        env_ref = ALL_ENVS[env_name]
+        env_ref = ALL_NATIVE_ENVS[env_name]
         from_, class_ = env_ref.split(":")
         imported = getattr(__import__(from_, fromlist=[class_]), class_)
         lines = inspect.getsource(imported)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "numpy",
     "gymnasium==0.29.*",
     "matplotlib",
+    "rapidfuzz==3.13.*",
     "stable-baselines3>=2.3.2",
     "scipy",
 ]

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -55,7 +55,11 @@ def test_run_all(verbose_success=False):
         warnings.filterwarnings("ignore", message=".*The environment creator metadata doesn't include `render_modes`*")
         for env_name in ENVS:
             print(env_name)
-            _test_run(env_name, verbose=verbose_success)
+            try:
+                _test_run(env_name, verbose=verbose_success)
+            except Exception as e:
+                msg = f"Invalid metadata for {env_name}. {e}"
+                raise gym.error.InvalidMetadata(msg) from e
 
 
 def _test_dataset(env):

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -2,6 +2,7 @@ import warnings
 
 import gymnasium as gym
 import numpy as np
+import pytest
 from matplotlib import pyplot as plt
 
 import neurogym as ngym
@@ -188,3 +189,12 @@ def test_plot_all():
                 print(f"Error in plotting env: {env_name}, {e}")
                 print(e)
             plt.close()
+
+
+def test_get_envs():
+    for task in ["GoNogo-v0", "GoNogo"]:
+        env = gym.make(task)
+        assert isinstance(env, gym.Env)
+        assert env.spec.id == "GoNogo-v0"
+    with pytest.raises(gym.error.UnregisteredEnv):
+        _env = gym.make("GoNogo-v1")


### PR DESCRIPTION
Done in this PR:
- in case env does not exist, try to append "-v0"
- make module more readable
- add documentation/type hints

The registration module is currently largely built in a roundabout way, where first a list of possible envs is manually given, and then the file space is scanned to see whether these envs actually exist. This could be simplified/made more maintainable by just scanning the files within a given folder tree and registering all encountered valid envs. We could specify an `ignore_env` list instead of an `allowed_env` list, if we want to allow the possibility of excluding specific envs (which would be the minority).

I think this would be a worthwhile improvement, but requires a bit more work, so wanted to check first if that is worthwhile.


Note:
The penultimate commit (a1e085b) is a re-ordering of where all the constants are. This makes it look like a lot has changed, but it's specifically only the location of specific parts of the code.