### PR TITLE
refactor: registration module

### DIFF
--- a/neurogym/envs/registration.py
+++ b/neurogym/envs/registration.py
@@ -206,44 +206,10 @@ def all_tags():
     ]
 
 
-def _distance(s0, s1):
-    # Copyright (c) 2018 luozhouyang
-    if s0 is None:
-        msg = "Argument s0 is NoneType."
-        raise TypeError(msg)
-    if s1 is None:
-        msg = "Argument s1 is NoneType."
-        raise TypeError(msg)
-    if s0 == s1:
-        return 0.0
-    if len(s0) == 0:
-        return len(s1)
-    if len(s1) == 0:
-        return len(s0)
-
-    v0 = [0] * (len(s1) + 1)
-    v1 = [0] * (len(s1) + 1)
-
-    for i in range(len(v0)):
-        v0[i] = i
-
-    for i in range(len(s0)):
-        v1[0] = i + 1
-        for j in range(len(s1)):
-            cost = 1
-            if s0[i] == s1[j]:
-                cost = 0
-            v1[j + 1] = min(v1[j] + 1, v0[j + 1] + 1, v0[j] + cost)
-        v0, v1 = v1, v0
-
-    return v0[len(s1)]
-
-
 def make(id_: str, **kwargs) -> gym.Env:
     """Creates an environment previously registered with :meth:`ngym.register`.
 
-    This function attempts to create an environment using the given `id_`. If the environment
-    is not registered, it raises an error and suggests the closest matching environment IDs.
+    This function calls the Gymnasium `make` function with the `disable_env_checker` argument set to True.
 
     Args:
         id_: A string representing the environment ID.
@@ -251,30 +217,9 @@ def make(id_: str, **kwargs) -> gym.Env:
 
     Returns:
         An instance of the environment.
-
-    Raises:
-        gym.error.UnregisteredEnv: If the `id_` doesn't exist in the Neurogym's registry. The error
-            message will include suggestions for the closest matching environment IDs.
     """
-    try:
-        # built in env_checker raises warnings or errors when ob not in observation_space
-        return gym.make(id_, disable_env_checker=True, **kwargs)
-
-    except gym.error.UnregisteredEnv as e:
-        # backward compatibility with old versions of gym
-        if hasattr(gym.envs.registry, "all"):
-            all_ids = [env.id for env in gym.envs.registry.all()]
-        else:
-            all_ids = [env.id for env in gym.envs.registry.values()]
-
-        dists = [_distance(id_, env_id) for env_id in all_ids]
-        # Python argsort
-        sort_inds = sorted(range(len(dists)), key=dists.__getitem__)
-        env_guesses = [all_ids[sort_inds[i]] for i in range(5)]
-        err_msg = f"No registered env with id_: {id_}.\nDo you mean:\n"
-        for env_guess in env_guesses:
-            err_msg += f"    {env_guess}\n"
-        raise gym.error.UnregisteredEnv(err_msg) from e
+    # built in env_checker raises warnings or errors when ob not in observation_space
+    return gym.make(id_, disable_env_checker=True, **kwargs)
 
 
 def register(id_: str, **kwargs) -> None:

--- a/neurogym/envs/registration.py
+++ b/neurogym/envs/registration.py
@@ -3,7 +3,6 @@ from inspect import getmembers, isclass, isfunction
 from pathlib import Path
 
 import gymnasium as gym
-from packaging import version
 
 from neurogym.envs.collections import get_collection
 
@@ -230,11 +229,8 @@ def _distance(s0, s1):
 
 def make(id_, **kwargs):
     try:
-        # TODO: disable gym 0.24 env_checker for now (raises warnings, even errors when ob not in observation_space)
-        # FIXME: is this still relevant for gymnasium?
-        if version.parse(gym.__version__) >= version.parse("0.24.0"):
-            return gym.make(id_, disable_env_checker=True, **kwargs)
-        return gym.make(id_, **kwargs)
+        # built in env_checker raises warnings or errors when ob not in observation_space
+        return gym.make(id_, disable_env_checker=True, **kwargs)
 
     except gym.error.UnregisteredEnv as e:
         # backward compatibility with old versions of gym
@@ -253,15 +249,9 @@ def make(id_, **kwargs):
         raise gym.error.UnregisteredEnv(err_msg) from e
 
 
-# backward compatibility with old versions of gym
-if hasattr(gym.envs.registry, "all"):
-    _all_gym_envs = [env.id for env in gym.envs.registry.all()]
-else:
-    _all_gym_envs = [env.id for env in gym.envs.registry.values()]
-
-
 def register(id_, **kwargs) -> None:
-    if id_ not in _all_gym_envs:
+    all_gym_envs = [env.id for env in gym.envs.registry.values()]
+    if id_ not in all_gym_envs:
         gym.envs.registration.register(id=id_, **kwargs)
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -79,7 +79,7 @@ def test_addob_instep():
         assert ob[0] == ((i + 1) % 5) + 1  # each trial is 5 steps
 
 
-class TestEnv(ngym.TrialEnv):
+class DummyEnv(ngym.TrialEnv):
     def __init__(self, dt: int, timing: dict, seed: int = 42) -> None:
         super().__init__(dt=dt)
         self.seed(seed)
@@ -134,7 +134,7 @@ class TestEnv(ngym.TrialEnv):
 def test_trial_length_stats(timing, expected_stats):
     """Test trial length stats for both fixed and randomized timing configurations."""
     dt = 100
-    env = TestEnv(dt=dt, timing=timing)
+    env = DummyEnv(dt=dt, timing=timing)
     stats = env.trial_length_stats(num_trials=1000)
 
     for key, expected in expected_stats.items():

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -8,7 +8,7 @@ import numpy as np
 import neurogym as ngym
 
 # Get all supervised learning environment
-SLENVS = ngym.all_envs(tag="supervised")
+SL_ENVS = ngym.all_envs(tag="supervised")
 
 
 def _test_env(env):
@@ -36,9 +36,12 @@ def test_registered_env():
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", message=".*get variables from other wrappers is deprecated*")
         warnings.filterwarnings("ignore", message=".*The environment creator metadata doesn't include `render_modes`*")
-        for env_name in sorted(SLENVS):
-            print(env_name)
-            _test_env(env_name)
+        try:
+            for env_name in sorted(SL_ENVS):
+                _test_env(env_name)
+        except:
+            print(f"Failure in: {env_name}")
+            raise
 
 
 def _test_examples_different(env) -> None:
@@ -64,9 +67,12 @@ def test_examples_different_registered_env():
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", message=".*get variables from other wrappers is deprecated*")
         warnings.filterwarnings("ignore", message=".*The environment creator metadata doesn't include `render_modes`*")
-        for env_name in sorted(SLENVS):
-            print(env_name)
-            _test_examples_different(env_name)
+        try:
+            for env_name in sorted(SL_ENVS):
+                _test_examples_different(env_name)
+        except:
+            print(f"Failure in: {env_name}")
+            raise
 
 
 def test_examples_different_made_env():
@@ -74,10 +80,13 @@ def test_examples_different_made_env():
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", message=".*get variables from other wrappers is deprecated*")
         warnings.filterwarnings("ignore", message=".*The environment creator metadata doesn't include `render_modes`*")
-        for env_name in sorted(SLENVS):
-            print(env_name)
-            env = gym.make(env_name)
-            _test_examples_different(env)
+        try:
+            for env_name in sorted(SL_ENVS):
+                env = gym.make(env_name)
+                _test_examples_different(env)
+        except:
+            print(f"Failure in: {env_name}")
+            raise
 
 
 def test_examples_different_custom_env():

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -1,4 +1,5 @@
 import warnings
+from importlib.util import find_spec
 
 import gymnasium as gym
 import numpy as np
@@ -8,17 +9,12 @@ from matplotlib import pyplot as plt
 import neurogym as ngym
 from neurogym.utils.data import Dataset
 
-try:
-    import psychopy  # noqa: F401
+_HAVE_PSYCHOPY = find_spec("psychopy") is not None  # check if psychopy is installed
+SEED = 0
 
-    _have_psychopy = True  # FIXME should psychopy be always tested, to ensure CI doesn't fail?
-except ImportError:
-    _have_psychopy = False
-
-ENVS = ngym.all_envs(psychopy=_have_psychopy, contrib=True, collections=True)
+ENVS = ngym.all_envs(psychopy=_HAVE_PSYCHOPY, contrib=True, collections=True)
 # Envs without psychopy, TODO: check if contrib or collections include psychopy
 ENVS_NOPSYCHOPY = ngym.all_envs(psychopy=False, contrib=True, collections=True)
-SEED = 0
 
 
 def _test_run(env, num_steps=100, verbose=False):
@@ -53,9 +49,12 @@ def test_run_all(verbose_success=False):
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", message=".*get variables from other wrappers is deprecated*")
         warnings.filterwarnings("ignore", message=".*The environment creator metadata doesn't include `render_modes`*")
-        for env_name in ENVS:
-            print(env_name)
-            _test_run(env_name, verbose=verbose_success)
+        try:
+            for env_name in ENVS:
+                _test_run(env_name, verbose=verbose_success)
+        except:
+            print(f"Failure at running env: {env_name}")
+            raise
 
 
 def _test_dataset(env):
@@ -99,11 +98,14 @@ def test_print_all():
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", message=".*get variables from other wrappers is deprecated*")
         warnings.filterwarnings("ignore", message=".*The environment creator metadata doesn't include `render_modes`*")
-        for env_name in ENVS:
-            print()
-            print(f"Test printing env: {env_name}")
-            env = ngym.make(env_name)
-            print(env)
+        try:
+            for env_name in ENVS:
+                print(f"Test printing env: {env_name}")
+                env = ngym.make(env_name)
+                print(env)
+        except:
+            print(f"Failure at printing env: {env_name}")
+            raise
 
 
 def _test_trialenv(env):
@@ -123,9 +125,13 @@ def test_trialenv_all():
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", message=".*get variables from other wrappers is deprecated*")
         warnings.filterwarnings("ignore", message=".*The environment creator metadata doesn't include `render_modes`*")
-        for env_name in ENVS:
-            env = ngym.make(env_name)
-            _test_trialenv(env)
+        try:
+            for env_name in ENVS:
+                env = ngym.make(env_name)
+                _test_trialenv(env)
+        except:
+            print(f"Failure with env: {env_name}")
+            raise
 
 
 def _test_seeding(env):
@@ -165,13 +171,16 @@ def test_seeding_all():
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", message=".*get variables from other wrappers is deprecated*")
         warnings.filterwarnings("ignore", message=".*The environment creator metadata doesn't include `render_modes`*")
-        for env_name in sorted(ENVS_NOPSYCHOPY):
-            print(f"Running env: {env_name}")
-            obs1, rews1, acts1 = _test_seeding(env_name)
-            obs2, rews2, acts2 = _test_seeding(env_name)
-            assert (obs1 == obs2).all(), "obs are not identical"
-            assert (rews1 == rews2).all(), "rewards are not identical"
-            assert (acts1 == acts2).all(), "actions are not identical"
+        try:
+            for env_name in sorted(ENVS_NOPSYCHOPY):
+                obs1, rews1, acts1 = _test_seeding(env_name)
+                obs2, rews2, acts2 = _test_seeding(env_name)
+                assert (obs1 == obs2).all(), "obs are not identical"
+                assert (rews1 == rews2).all(), "rewards are not identical"
+                assert (acts1 == acts2).all(), "actions are not identical"
+        except:
+            print(f"Failure with env: {env_name}")
+            raise
 
 
 def test_plot_all():

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -2,6 +2,7 @@ import warnings
 
 import gymnasium as gym
 import numpy as np
+import pytest
 from matplotlib import pyplot as plt
 
 import neurogym as ngym
@@ -188,3 +189,16 @@ def test_plot_all():
                 print(f"Error in plotting env: {env_name}, {e}")
                 print(e)
             plt.close()
+
+
+def test_get_envs():
+    for task in ["GoNogo-v0", "GoNogo"]:
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message=".*Using the latest versioned environment*")
+            warnings.filterwarnings("ignore", message=".*The environment creator metadata doesn't include*")
+            env = gym.make(task)
+        assert isinstance(env, gym.Env)
+        assert env.spec.id == "GoNogo-v0"
+    for invalid in ["GoNogo-v99", "GoGoNo"]:
+        with pytest.raises(gym.error.UnregisteredEnv):
+            _env = gym.make(invalid)


### PR DESCRIPTION
Can be reviewed commit by commit.

### Summary by CoPilot

This PR improves maintainability, testability, and dynamic handling of environments in the neurogym package.

1. Environment Registration Refactor:
    - The `_get_envs` function has been rewritten to dynamically discover and register environments by scanning Python files in specified folders. It now supports excluding specific environments via the `_EXCLUDE_ENVS` list.
    - Removed hardcoded environment lists and replaced them with dynamic discovery.
    - Added `_HAVE_PSYCHOPY` and `_INCLUDE_CONTRIB` flags to conditionally include environments based on dependencies or testing status.
2. Test Updates:
    - Updated test cases to use the new dynamic environment registration logic.
    - Added a new test `test_get_envs` to validate environment registration and handle invalid environment IDs.
    - Added `try-except` blocks in test functions to catch and log failures for individual environments, improving debugging during test runs.
3. Code Cleanup:
    - Simplified the `register` and `make` functions by removing backward compatibility checks for older Gym versions.
    - Removed unused or outdated code, such as `_distance` and legacy environment registration logic.
    - Consolidated environment registration logic for native, contrib, and psychopy environments.
        - This has not been done yet for the collections environments, as these are created using a slightly different logic.

closes #150 