### PR TITLE
ci: fix static typing workflow

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.11
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: 3.11
       - name: Python info

--- a/.github/workflows/release_github.yml
+++ b/.github/workflows/release_github.yml
@@ -90,7 +90,7 @@ jobs:
           git merge ${{ github.ref_name }} --no-ff --no-edit
 
       - name: Install Python
-        uses: actions/setup-python@v5.1.1
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Fetch gh-pages
         run: git fetch origin gh-pages:gh-pages
       - name: Install Python
-        uses: actions/setup-python@v5.1.1
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
       - name: Install requirements

--- a/.github/workflows/static-typing.yml
+++ b/.github/workflows/static-typing.yml
@@ -28,7 +28,7 @@ on:
       - "**.png"
 
 jobs:
-  lint:
+  static-typing:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
@@ -43,10 +43,11 @@ jobs:
           which python3
           python3 --version
       - name: Upgrade pip and install dependencies
+        # avoid installing gpu dependencies by first installing cpu-only torch
         run: |
           python3 -m pip install --upgrade pip setuptools
-          pip install mypy types-toml
+          pip install torch --index-url https://download.pytorch.org/whl/cpu
+          pip install .[rl,dev]
       # mypy configs are in pyproject.toml
       - name: Check static typing
-        run: |
-          mypy neurogym tests
+        run: mypy neurogym tests

--- a/.github/workflows/static-typing.yml
+++ b/.github/workflows/static-typing.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.11
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
       - name: Python info

--- a/neurogym/envs/contrib/anglereproduction.py
+++ b/neurogym/envs/contrib/anglereproduction.py
@@ -117,7 +117,7 @@ class AngleReproduction(ngym.TrialEnv):
 
 
 if __name__ == "__main__":
-    from neurogym.tests import test_run
+    from neurogym.tests import test_run  # type: ignore  # noqa: PGH003
 
     env = AngleReproduction()
     test_run(env)

--- a/neurogym/utils/data.py
+++ b/neurogym/utils/data.py
@@ -57,10 +57,12 @@ class Dataset:
 
         obs_shape = env.observation_space.shape
         action_shape = env.action_space.shape
-        if len(action_shape) == 0:
-            self._expand_action = True
-        else:
-            self._expand_action = False
+        if obs_shape is None or action_shape is None:
+            msg = "The observation and action spaces must have a shape."
+            raise ValueError(msg)
+
+        self._expand_action = len(action_shape) == 0
+
         if cache_len is None:
             # Infer cache len
             cache_len = 1e5  # Probably too low

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,5 +90,5 @@ exclude = ["tests*"]
 python_version = "3.11"
 warn_return_any = true
 warn_unused_configs = true
-ignore_missing_imports = true
 show_error_codes = true
+exclude = "build/.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,10 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "numpy",
+    "numpy==2.1.*",
     "gymnasium==0.29.*",
-    "matplotlib",
-    "scipy",
+    "matplotlib==3.9.*",
+    "scipy==1.14.*",
 ]
 description = "NeuroGym: Gymnasium-style Cognitive Neuroscience Tasks"
 keywords = [
@@ -48,6 +48,7 @@ dev = [
     # code style
     "ruff==0.9.*",
     "mypy",
+    "scipy-stubs",
     # docs
     "mkdocs",
     "mkdocs-material",
@@ -62,10 +63,7 @@ dev = [
 publishing = ["build", "twine", "wheel"]
 tutorials = ["notebook"]
 env_specific = ["psychopy"]
-rl = [
-    "stable-baselines3>=2.3.2",
-    "sb3-contrib",
-]
+rl = ["stable-baselines3>=2.3.2", "sb3-contrib"]
 
 [project.urls]
 Repository = "https://github.com/neurogym/neurogym"
@@ -92,3 +90,7 @@ warn_return_any = true
 warn_unused_configs = true
 show_error_codes = true
 exclude = "build/.*"
+
+[[tool.mypy.overrides]]
+module = "psychopy"
+ignore_missing_imports = true


### PR DESCRIPTION
The static typing workflow previously did not install the current package + had `ignore_missing_imports` set to true. This led to the GitHub workflow not picking up some issues (which were picked up locally if the package _is_ installed)

The main issue is due to incorrect type inference in utils/data.py, which was solved in #145 I copied the code that solves this issue from there. This should not lead to merge conflicts, because the code is identical (cherry picking was not possible because of other changes in the same commit).