### PR TITLE
docs: RL install instructions for CPU only

### DIFF
--- a/README.dev.md
+++ b/README.dev.md
@@ -22,6 +22,15 @@ pip install -e .'[rl,dev]'
 
 Note: you can also run this command after completing the "normal" installation instructions from the [README](README.md#installation).
 
+**NOTE for Linux/WSL users:** If you do not have access to a CUDA-capable NVIDIA GPU (which is the case for most users),
+above line will install up to 1.5GB of unnecessary GPU libraries. To avoid excessive overhead, we recommend first
+isntalling the CPU-only version of [PyTorch](https://pytorch.org/get-started/locally/):
+
+```bash
+pip install torch --index-url https://download.pytorch.org/whl/cpu
+pip install neurogym[rl,dev]
+```
+
 ## Running the tests
 
 You can check that all components were installed correctly, by running [pytest](https://docs.pytest.org/en/stable/#) from your terminal:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Please see our extended project [documentation](https://neurogym.github.io/neuro
 
 ### Installation
 
-#### Step 1: Create a virtual environment
+#### 1: Create a virtual environment
 
 Create and activate a virtual environment to install the current package, e.g. using
 [conda](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html) (please refer to their
@@ -48,35 +48,35 @@ conda create -n neurogym python=3.11 -y
 conda activate neurogym
 ```
 
-#### Step 2: Install NeuroGym
+#### 2: Install NeuroGym
 
-You can install the latest stable release of `neurogym` using pip:
+Install the latest stable release of `neurogym` using pip:
 
 ```bash
 pip install neurogym
 ```
 
-##### Reinforcent learning
+##### 2a: Reinforcement Learning Support
 
-If you plan to use reinforcement learning (RL) features based on Stable-Baselines3, install the RL extra dependencies.
+NeuroGym includes optional reinforcement learning (RL) features via Stable-Baselines3. To install these:
 
-If you are planning to run reinforcement learning pipelines on GPU (using CUDA), run:
-
-```bash
-pip install neurogym[rl]
-```
-
-If you only have access to GPU (i.e. most personal computers), we recommend to first install the CPU-only version of
-pytorch first, to avoid installing ~2,5GB of dependencies required only for GPU:
+If you do not have a CUDA-capable NVIDIA GPU (which is the case for most users), we recommend installing the CPU-only
+version of [PyTorch](https://pytorch.org/get-started/locally/) to avoid downloading unnecessary GPU libraries (up to 1.5GB):
 
 ```bash
 pip install torch --index-url https://download.pytorch.org/whl/cpu
 pip install neurogym[rl]
 ```
 
-##### Step 2b: Install in Editable/Development Mode
+If you do have a properly configured CUDA setup, you can install the GPU-compatible version:
 
-If you want to contribute to NeuroGym or always work with the latest updates from the source code, install it in editable mode:
+```bash
+pip install neurogym[rl]
+```
+
+##### 2b: Editable/Development Mode
+
+To contribute to NeuroGym or run it from source with live code updates:
 
 ```bash
 git clone https://github.com/neurogym/neurogym.git
@@ -84,9 +84,9 @@ cd neurogym
 pip install -e .
 ```
 
-This links your local code changes directly to your Python environment without needing to reinstall after every edit.
+This installs the package in editable mode, so changes in source files are reflected without reinstalling.
 
-If you also want RL and development tools (for testing, linting, and documentation), install with:
+To include both RL and development tools (e.g., for testing, linting, documentation):
 
 ```bash
 pip install -e .[rl,dev]

--- a/README.md
+++ b/README.md
@@ -58,9 +58,12 @@ pip install neurogym
 
 ##### 2a: Reinforcement Learning Support
 
-NeuroGym includes optional reinforcement learning (RL) features via Stable-Baselines3. To install these:
+NeuroGym includes optional reinforcement learning (RL) features via Stable-Baselines3.
+To install these, choose one of the two options below depending on your hardware setup:
 
-If you do not have a CUDA-capable NVIDIA GPU (which is the case for most users), we recommend installing the CPU-only
+###### Option A — CPU-only (recommended for most users):
+
+If you **do not** have a CUDA-capable NVIDIA GPU (which is the case for most users), we recommend installing the CPU-only
 version of [PyTorch](https://pytorch.org/get-started/locally/) to avoid downloading unnecessary GPU libraries (up to 1.5GB):
 
 ```bash
@@ -68,7 +71,9 @@ pip install torch --index-url https://download.pytorch.org/whl/cpu
 pip install neurogym[rl]
 ```
 
-If you do have a properly configured CUDA setup, you can install the GPU-compatible version:
+###### Option B — GPU support:
+
+If you **do** have a properly configured CUDA setup, you can install the GPU-compatible version:
 
 ```bash
 pip install neurogym[rl]

--- a/README.md
+++ b/README.md
@@ -56,9 +56,21 @@ You can install the latest stable release of `neurogym` using pip:
 pip install neurogym
 ```
 
-If you plan to use reinforcement learning (RL) features based on Stable-Baselines3, install the RL extra dependencies:
+##### Reinforcent learning
+
+If you plan to use reinforcement learning (RL) features based on Stable-Baselines3, install the RL extra dependencies.
+
+If you are planning to run reinforcement learning pipelines on GPU (using CUDA), run:
 
 ```bash
+pip install neurogym[rl]
+```
+
+If you only have access to GPU (i.e. most personal computers), we recommend to first install the CPU-only version of
+pytorch first, to avoid installing ~2,5GB of dependencies required only for GPU:
+
+```bash
+pip install torch --index-url https://download.pytorch.org/whl/cpu
 pip install neurogym[rl]
 ```
 

--- a/README.md
+++ b/README.md
@@ -61,21 +61,16 @@ pip install neurogym
 NeuroGym includes optional reinforcement learning (RL) features via Stable-Baselines3.
 To install these, choose one of the two options below depending on your hardware setup:
 
-###### Option A — CPU-only (recommended for most users):
-
-If you **do not** have a CUDA-capable NVIDIA GPU (which is the case for most users), we recommend installing the CPU-only
-version of [PyTorch](https://pytorch.org/get-started/locally/) to avoid downloading unnecessary GPU libraries (up to 1.5GB):
-
 ```bash
-pip install torch --index-url https://download.pytorch.org/whl/cpu
 pip install neurogym[rl]
 ```
 
-###### Option B — GPU support:
-
-If you **do** have a properly configured CUDA setup, you can install the GPU-compatible version:
+**NOTE for Linux/WSL users:** If you do not have access to a CUDA-capable NVIDIA GPU (which is the case for most users),
+above line will install up to 1.5GB of unnecessary GPU libraries. To avoid excessive overhead, we recommend first
+isntalling the CPU-only version of [PyTorch](https://pytorch.org/get-started/locally/):
 
 ```bash
+pip install torch --index-url https://download.pytorch.org/whl/cpu
 pip install neurogym[rl]
 ```
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-## Step 1: Create a virtual environment
+## 1: Create a virtual environment
 
 Create and activate a virtual environment to install the current package, e.g. using
 [conda](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html) (please refer to their
@@ -12,23 +12,35 @@ conda create -n neurogym python=3.11 -y
 conda activate neurogym
 ```
 
-## Step 2: Install NeuroGym
+## 2: Install NeuroGym
 
-You can install the latest stable release of `neurogym` using pip:
+Install the latest stable release of `neurogym` using pip:
 
 ```bash
 pip install neurogym
 ```
 
-If you plan to use reinforcement learning (RL) features based on Stable-Baselines3, install the RL extra dependencies:
+### 2a: Reinforcement Learning Support
+
+NeuroGym includes optional reinforcement learning (RL) features via Stable-Baselines3. To install these:
+
+If you do not have a CUDA-capable NVIDIA GPU (which is the case for most users), we recommend installing the CPU-only
+version of [PyTorch](https://pytorch.org/get-started/locally/) to avoid downloading unnecessary GPU libraries (up to 1.5GB):
+
+```bash
+pip install torch --index-url https://download.pytorch.org/whl/cpu
+pip install neurogym[rl]
+```
+
+If you do have a properly configured CUDA setup, you can install the GPU-compatible version:
 
 ```bash
 pip install neurogym[rl]
 ```
 
-### Step 2b: Install in Editable/Development Mode
+### 2b: Editable/Development Mode
 
-If you want to contribute to NeuroGym or always work with the latest updates from the source code, install it in editable mode:
+To contribute to NeuroGym or run it from source with live code updates:
 
 ```bash
 git clone https://github.com/neurogym/neurogym.git
@@ -36,9 +48,9 @@ cd neurogym
 pip install -e .
 ```
 
-This links your local code changes directly to your Python environment without needing to reinstall after every edit.
+This installs the package in editable mode, so changes in source files are reflected without reinstalling.
 
-If you also want RL and development tools (for testing, linting, and documentation), install with:
+To include both RL and development tools (e.g., for testing, linting, documentation):
 
 ```bash
 pip install -e .[rl,dev]

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -22,9 +22,12 @@ pip install neurogym
 
 ### 2a: Reinforcement Learning Support
 
-NeuroGym includes optional reinforcement learning (RL) features via Stable-Baselines3. To install these:
+NeuroGym includes optional reinforcement learning (RL) features via Stable-Baselines3.
+To install these, choose one of the two options below depending on your hardware setup:
 
-If you do not have a CUDA-capable NVIDIA GPU (which is the case for most users), we recommend installing the CPU-only
+#### Option A — CPU-only (recommended for most users):
+
+If you **do not** have a CUDA-capable NVIDIA GPU (which is the case for most users), we recommend installing the CPU-only
 version of [PyTorch](https://pytorch.org/get-started/locally/) to avoid downloading unnecessary GPU libraries (up to 1.5GB):
 
 ```bash
@@ -32,7 +35,9 @@ pip install torch --index-url https://download.pytorch.org/whl/cpu
 pip install neurogym[rl]
 ```
 
-If you do have a properly configured CUDA setup, you can install the GPU-compatible version:
+#### Option B — GPU support:
+
+If you **do** have a properly configured CUDA setup, you can install the GPU-compatible version:
 
 ```bash
 pip install neurogym[rl]

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,19 +27,19 @@ To install these, choose one of the two options below depending on your hardware
 
 #### Option A — CPU-only (recommended for most users):
 
-If you **do not** have a CUDA-capable NVIDIA GPU (which is the case for most users), we recommend installing the CPU-only
-version of [PyTorch](https://pytorch.org/get-started/locally/) to avoid downloading unnecessary GPU libraries (up to 1.5GB):
+NeuroGym includes optional reinforcement learning (RL) features via Stable-Baselines3.
+To install these, choose one of the two options below depending on your hardware setup:
 
 ```bash
-pip install torch --index-url https://download.pytorch.org/whl/cpu
 pip install neurogym[rl]
 ```
 
-#### Option B — GPU support:
-
-If you **do** have a properly configured CUDA setup, you can install the GPU-compatible version:
+**NOTE for Linux/WSL users:** If you do not have access to a CUDA-capable NVIDIA GPU (which is the case for most users),
+above line will install up to 1.5GB of unnecessary GPU libraries. To avoid excessive overhead, we recommend first
+isntalling the CPU-only version of [PyTorch](https://pytorch.org/get-started/locally/):
 
 ```bash
+pip install torch --index-url https://download.pytorch.org/whl/cpu
 pip install neurogym[rl]
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,8 +66,6 @@ dev = [
     "bump-my-version",
 ]
 publishing = ["build", "twine", "wheel"]
-tutorials = ["notebook"]
-env_specific = ["psychopy"]
 rl = ["stable-baselines3>=2.3.2", "sb3-contrib"]
 
 [project.urls]


### PR DESCRIPTION
related to #168: pytorch by default comes with a large number of packages (in excess of 1GB) that are only relevant for CUDA. Given that many/most users will not have access to CUDA, I have added instructions how install CPU only version ([this cannot be done directly via PyPi](https://github.com/pytorch/pytorch/issues/26340)).

Also asked ChatGPT to rephrase the install instructions slightly, as this was getting a bit messy.