### PR TITLE
docs: fix notebook and colab tab titles

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*.json]
+indent_style = space
+indent_size = 2
+
+[*.ipynb]
+indent_style = space
+indent_size = 1

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,12 +25,15 @@
   // Format all files on save
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "[ignore]": {
-    "editor.defaultFormatter": "foxundermoon.shell-format"
-  },
   "rewrap.wrappingColumn": 120,
   "rewrap.autoWrap.enabled": true,
   "files.trimTrailingWhitespace": true,
   "files.trimFinalNewlines": true,
-  "files.insertFinalNewline": true
+  "files.insertFinalNewline": true,
+  "[ignore]": {
+    "editor.defaultFormatter": "foxundermoon.shell-format"
+  },
+  "[properties]": {
+    "editor.defaultFormatter": "foxundermoon.shell-format"
+  }
 }

--- a/docs/examples/demo.ipynb
+++ b/docs/examples/demo.ipynb
@@ -285,14 +285,11 @@
  "metadata": {
   "accelerator": "GPU",
   "colab": {
-   "collapsed_sections": [],
-   "include_colab_link": true,
-   "name": "example_neurogym_rl.ipynb",
-   "provenance": []
+   "name": "Exploring NeuroGym tasks"
   },
   "hide_input": false,
   "kernelspec": {
-   "display_name": "neurogym",
+   "display_name": "ngym",
    "language": "python",
    "name": "python3"
   },
@@ -306,7 +303,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.11.10"
   },
   "toc": {
    "base_numbering": 1,

--- a/docs/examples/demo.ipynb
+++ b/docs/examples/demo.ipynb
@@ -18,7 +18,7 @@
     "id": "4zW6CU8F69Zp"
    },
    "source": [
-    "## Exploring NeuroGym tasks\n"
+    "## Exploring NeuroGym Tasks\n"
    ]
   },
   {
@@ -285,7 +285,7 @@
  "metadata": {
   "accelerator": "GPU",
   "colab": {
-   "name": "Exploring NeuroGym tasks"
+   "name": "Exploring NeuroGym Tasks"
   },
   "hide_input": false,
   "kernelspec": {

--- a/docs/examples/reinforcement_learning.ipynb
+++ b/docs/examples/reinforcement_learning.ipynb
@@ -15,7 +15,7 @@
     "id": "4zW6CU8F69Zp"
    },
    "source": [
-    "## NeuroGym: Reinforcement learning (stable-baselines3)\n",
+    "## NeuroGym: Reinforcement Learning (stable-baselines3)\n",
     "\n",
     "NeuroGym is a toolkit that allows training any network model on many established neuroscience tasks techniques such as standard Supervised Learning or Reinforcement Learning (RL). In this notebook we will use RL to train an LSTM network on the classical Random Dots Motion (RDM) task (Britten et al. 1992).\n",
     "\n",
@@ -197,7 +197,7 @@
  "metadata": {
   "accelerator": "GPU",
   "colab": {
-   "name": "NeuroGym: Reinforcement learning (stable-baselines3)"
+   "name": "NeuroGym: Reinforcement Learning (stable-baselines3)"
   },
   "hide_input": false,
   "kernelspec": {

--- a/docs/examples/reinforcement_learning.ipynb
+++ b/docs/examples/reinforcement_learning.ipynb
@@ -197,10 +197,7 @@
  "metadata": {
   "accelerator": "GPU",
   "colab": {
-   "collapsed_sections": [],
-   "include_colab_link": true,
-   "name": "example_neurogym_rl.ipynb",
-   "provenance": []
+   "name": "NeuroGym: Reinforcement learning (stable-baselines3)"
   },
   "hide_input": false,
   "kernelspec": {

--- a/docs/examples/reinforcement_learning.ipynb
+++ b/docs/examples/reinforcement_learning.ipynb
@@ -15,7 +15,7 @@
     "id": "4zW6CU8F69Zp"
    },
    "source": [
-    "## NeuroGym: Reinforcement Learning (stable-baselines3)\n",
+    "## Neurogym withReinforcement Learning (stable-baselines3)\n",
     "\n",
     "NeuroGym is a toolkit that allows training any network model on many established neuroscience tasks techniques such as standard Supervised Learning or Reinforcement Learning (RL). In this notebook we will use RL to train an LSTM network on the classical Random Dots Motion (RDM) task (Britten et al. 1992).\n",
     "\n",
@@ -197,7 +197,7 @@
  "metadata": {
   "accelerator": "GPU",
   "colab": {
-   "name": "NeuroGym: Reinforcement Learning (stable-baselines3)"
+   "name": "Neurogym withReinforcement Learning (stable-baselines3)"
   },
   "hide_input": false,
   "kernelspec": {

--- a/docs/examples/reinforcement_learning.ipynb
+++ b/docs/examples/reinforcement_learning.ipynb
@@ -15,7 +15,7 @@
     "id": "4zW6CU8F69Zp"
    },
    "source": [
-    "## Reinforcement learning example with stable-baselines3\n",
+    "## NeuroGym: Reinforcement learning (stable-baselines3)\n",
     "\n",
     "NeuroGym is a toolkit that allows training any network model on many established neuroscience tasks techniques such as standard Supervised Learning or Reinforcement Learning (RL). In this notebook we will use RL to train an LSTM network on the classical Random Dots Motion (RDM) task (Britten et al. 1992).\n",
     "\n",

--- a/docs/examples/supervised_learning_keras.ipynb
+++ b/docs/examples/supervised_learning_keras.ipynb
@@ -14,7 +14,7 @@
     "id": "4zW6CU8F69Zp"
    },
    "source": [
-    "## Keras example of supervised learning a NeuroGym task\n",
+    "## NeuroGym: Supervised Learning (keras)\n",
     "\n",
     "NeuroGym is a comprehensive toolkit that allows training any network model on many established neuroscience tasks using Reinforcement Learning techniques. It includes working memory tasks, value-based decision tasks and context-dependent perceptual categorization tasks.\n",
     "\n",

--- a/docs/examples/supervised_learning_keras.ipynb
+++ b/docs/examples/supervised_learning_keras.ipynb
@@ -14,7 +14,7 @@
     "id": "4zW6CU8F69Zp"
    },
    "source": [
-    "## NeuroGym: Supervised Learning (keras)\n",
+    "## Neurogym withSupervised Learning (keras)\n",
     "\n",
     "NeuroGym is a comprehensive toolkit that allows training any network model on many established neuroscience tasks using Reinforcement Learning techniques. It includes working memory tasks, value-based decision tasks and context-dependent perceptual categorization tasks.\n",
     "\n",
@@ -192,7 +192,7 @@
  "metadata": {
   "accelerator": "GPU",
   "colab": {
-   "name": "NeuroGym: Supervised learning (keras)"
+   "name": "Neurogym withSupervised learning (keras)"
   },
   "hide_input": false,
   "kernelspec": {

--- a/docs/examples/supervised_learning_keras.ipynb
+++ b/docs/examples/supervised_learning_keras.ipynb
@@ -192,9 +192,7 @@
  "metadata": {
   "accelerator": "GPU",
   "colab": {
-   "collapsed_sections": [],
-   "name": "Copy of example_NeuroGym_keras.ipynb",
-   "provenance": []
+   "name": "NeuroGym: Supervised learning (keras)"
   },
   "hide_input": false,
   "kernelspec": {

--- a/docs/examples/supervised_learning_pytorch.ipynb
+++ b/docs/examples/supervised_learning_pytorch.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## NeuroGym: Supervised Learning (pytorch)\n",
+    "## Neurogym withSupervised Learning (pytorch)\n",
     "\n",
     "Pytorch-based example code for training a RNN on a perceptual decision-making task.\n"
    ]
@@ -165,7 +165,7 @@
  "metadata": {
   "accelerator": "GPU",
   "colab": {
-   "name": "NeuroGym: Supervised Learning (pytorch)"
+   "name": "Neurogym withSupervised Learning (pytorch)"
   },
   "kernelspec": {
    "display_name": "ngym",

--- a/docs/examples/supervised_learning_pytorch.ipynb
+++ b/docs/examples/supervised_learning_pytorch.ipynb
@@ -163,8 +163,12 @@
   }
  ],
  "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "name": "NeuroGym: Supervised Learning (pytorch)"
+  },
   "kernelspec": {
-   "display_name": "temp_neurogym",
+   "display_name": "ngym",
    "language": "python",
    "name": "python3"
   },
@@ -178,7 +182,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.11"
+   "version": "3.11.10"
   }
  },
  "nbformat": 4,

--- a/docs/examples/supervised_learning_pytorch.ipynb
+++ b/docs/examples/supervised_learning_pytorch.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Pytorch supervised learning of perceptual decision making task\n",
+    "## NeuroGym: Supervised Learning (pytorch)\n",
     "\n",
     "Pytorch-based example code for training a RNN on a perceptual decision-making task.\n"
    ]

--- a/docs/examples/understanding_neurogym_task.ipynb
+++ b/docs/examples/understanding_neurogym_task.ipynb
@@ -653,6 +653,9 @@
   }
  ],
  "metadata": {
+  "colab": {
+   "name": "Understanding NeuroGym Tasks"
+  },
   "kernelspec": {
    "display_name": "ngym",
    "language": "python",

--- a/docs/examples/understanding_neurogym_task.ipynb
+++ b/docs/examples/understanding_neurogym_task.ipynb
@@ -11,13 +11,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Understanding Neurogym Task\n",
+    "## Understanding NeuroGym Tasks\n",
     "\n",
-    "This is a tutorial for understanding Neurogym task structure. Here we will go through\n",
+    "This is a tutorial for understanding NeuroGym task structure. Here we will go through\n",
     "\n",
     "1. Defining a basic gymnasium task\n",
     "2. Defining a basic trial-based neurogym task\n",
-    "3. Adding observation and ground truth in neurogym tasks\n"
+    "3. Adding observation and ground truth in NeuroGym tasks\n"
    ]
   },
   {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,7 @@ nav:
       - NeuroGym with RL: examples/reinforcement_learning.ipynb
       - NeuroGym with PyTorch: examples/supervised_learning_pytorch.ipynb
       - NeuroGym with Keras: examples/supervised_learning_keras.ipynb
+      - Example template for contributing new tasks: examples/template.py
   - Env specific examples:
       - Annubes: examples/annubes.ipynb
       - ContextDecisionmaking: examples/contextdecisionmaking.ipynb

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,7 +55,6 @@ nav:
       - NeuroGym with RL: examples/reinforcement_learning.ipynb
       - NeuroGym with PyTorch: examples/supervised_learning_pytorch.ipynb
       - NeuroGym with Keras: examples/supervised_learning_keras.ipynb
-      - Example template for contributing new tasks: examples/template_task.py
   - Env specific examples:
       - Annubes: examples/annubes.ipynb
       - ContextDecisionmaking: examples/contextdecisionmaking.ipynb


### PR DESCRIPTION
The google colab links work, but the tab display titles were off. That is fixed here. I also gave the notebooks clearer titles.

Note that I needed to add the .editorconfig file to avoid vscode from automatically re-indenting the notebooks when I started manually changing the metadata fields.

Finally, i removed a link to template.py from the docs. This was giving a 404. Do you want that solved in a different way?