### PR TITLE
ci: remove stub from workflow

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           which python
           python --version
-      - name: Install ruff
+      - name: Install ruff version as listed in pyproject.toml
         run: |
           python3 -m pip install pyproject-deplister
           pyproject-deplister --extra dev --path pyproject.toml | grep ruff | sed 's/ //g' | xargs -I{} python3 -m pip install "{}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dev = [
     "pytest-cov",
     "coverage [toml]",
     # code style
-    "ruff==0.9.*",
+    "ruff==0.11.*",
     "mypy",
     "types-docutils",
     "scipy-stubs",


### PR DESCRIPTION
fail-fast has no effect if there is no matrix