### PR TITLE
docs: add ref to the new vanilla RNN policy in `stable-baseline3-contrib`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,20 @@ NeuroGym is a curated collection of neuroscience tasks with a common interface. 
 
 - [NeuroGym](#neurogym)
   - [Installation](#installation)
-    - [Step 1: Create a virtual environment](#step-1-create-a-virtual-environment)
-    - [Step 2: Install NeuroGym](#step-2-install-neurogym)
-      - [Step 2b: Install in Editable/Development Mode](#step-2b-install-in-editabledevelopment-mode)
-    - [Step 3 (Optional): Psychopy installation](#step-3-optional-psychopy-installation)
+    - [1. Create a Virtual Environment](#1-create-a-virtual-environment)
+    - [2. Install NeuroGym](#2-install-neurogym)
+      - [2.1 Reinforcement Learning Support](#21-reinforcement-learning-support)
+      - [2.2: Editable/Development Mode](#22-editabledevelopment-mode)
+    - [3. Psychopy Installation (Optional)](#3-psychopy-installation-optional)
   - [Tasks](#tasks)
   - [Wrappers](#wrappers)
   - [Configuration](#configuration)
-    - [1. From a TOML file](#1-from-a-toml-file)
-    - [2. With Python class](#2-with-python-class)
-    - [3. With a dictionary](#3-with-a-dictionary)
+    - [1. From a TOML File](#1-from-a-toml-file)
+    - [2. With Python Class](#2-with-python-class)
+    - [3. With a Dictionary](#3-with-a-dictionary)
   - [Examples](#examples)
-  - [Custom tasks](#custom-tasks)
+    - [Vanilla RNN Support in RecurrentPPO](#vanilla-rnn-support-in-recurrentppo)
+  - [Custom Tasks](#custom-tasks)
   - [Acknowledgements](#acknowledgements)
 
 NeuroGym inherits from the machine learning toolkit [Gymnasium](https://gymnasium.farama.org/), a maintained fork of [OpenAI’s Gym library](https://github.com/openai/gym). It allows a wide range of well established machine learning algorithms to be easily trained on behavioral paradigms relevant for the neuroscience community.
@@ -36,7 +38,7 @@ Please see our extended project [documentation](https://neurogym.github.io/neuro
 
 ### Installation
 
-#### 1: Create a virtual environment
+#### 1. Create a Virtual Environment
 
 Create and activate a virtual environment to install the current package, e.g. using
 [conda](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html) (please refer to their
@@ -48,7 +50,7 @@ conda create -n neurogym python=3.11 -y
 conda activate neurogym
 ```
 
-#### 2: Install NeuroGym
+#### 2. Install NeuroGym
 
 Install the latest stable release of `neurogym` using pip:
 
@@ -56,7 +58,7 @@ Install the latest stable release of `neurogym` using pip:
 pip install neurogym
 ```
 
-##### 2a: Reinforcement Learning Support
+##### 2.1 Reinforcement Learning Support
 
 NeuroGym includes optional reinforcement learning (RL) features via Stable-Baselines3.
 To install these, choose one of the two options below depending on your hardware setup:
@@ -74,7 +76,7 @@ pip install torch --index-url https://download.pytorch.org/whl/cpu
 pip install neurogym[rl]
 ```
 
-##### 2b: Editable/Development Mode
+##### 2.2: Editable/Development Mode
 
 To contribute to NeuroGym or run it from source with live code updates:
 
@@ -92,7 +94,7 @@ To include both RL and development tools (e.g., for testing, linting, documentat
 pip install -e .[rl,dev]
 ```
 
-#### Step 3 (Optional): Psychopy installation
+#### 3. Psychopy Installation (Optional)
 
 **NOTE**: psycohopy installation is currently not working
 
@@ -121,7 +123,7 @@ NeuroGym includes a flexible configuration mechanism using [`Pydantic Settings`]
 
 Using a TOML file can be especially useful for sharing experiment configurations in a portable way (e.g., sending `config.toml` to a colleague), reliably saving and loading experiment setups, and easily switching between multiple configurations for the same environment by changing just one line of code. While the system isn't at that stage yet, these are intended future capabilities.
 
-#### 1. From a TOML file
+#### 1. From a TOML File
 
 Create a `config.toml` file (see [template](docs/examples/config.toml)) and load it:
 
@@ -144,7 +146,7 @@ Or directly pass the path:
 env = monitor.Monitor(env, config='path/to/config.toml')
 ```
 
-#### 2. With Python class
+#### 2. With Python Class
 
 ```python
 from neurogym import Config
@@ -155,7 +157,7 @@ config = Config(
 )
 ```
 
-#### 3. With a dictionary
+#### 3. With a Dictionary
 
 ```python
 from neurogym import Config
@@ -175,7 +177,30 @@ config = Config.model_validate(config_dict)
 NeuroGym is compatible with most packages that use gymnasium.
 In this [example](https://github.com/neurogym/neurogym/blob/main/docs/examples/example_neurogym_rl.ipynb) jupyter notebook we show how to train a neural network with RL algorithms using the [Stable-Baselines3](https://stable-baselines3.readthedocs.io/en/master/) toolbox.
 
-### Custom tasks
+#### Vanilla RNN Support in RecurrentPPO
+
+We extended the [`RecurrentPPO`](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) implementation from `stable-baselines3-contrib` to support **vanilla RNNs** (`torch.nn.RNN`) in addition to LSTMs. This is particularly useful for neuroscience applications, where simpler recurrent architectures can be more biologically interpretable.
+
+You can enable vanilla RNNs by setting `recurrent_layer_type="rnn"` in the `policy_kwargs`:
+
+```python
+from sb3_contrib import RecurrentPPO
+
+policy_kwargs = {"recurrent_layer_type": "rnn"}  # "lstm" is the default
+model = RecurrentPPO("MlpLstmPolicy", env_vec, policy_kwargs=policy_kwargs, verbose=1)
+model.learn(5000)
+```
+
+> Note: This feature is part of an [open pull request](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib/pull/296) to the upstream repository and is currently under review by the maintainers. Until the pull request is merged, you can use this functionality by installing NeuroGym organization's fork of the repository. To do so, uninstall the original package and install from the custom branch:
+>
+> ```bash
+> pip uninstall stable-baselines3-contrib -y
+> pip install git+https://github.com/neurogym/stable-baselines3-contrib.git@rnn_policy_addition
+> ```
+>
+> This will install the version with vanilla RNN support from the `rnn_policy_addition` branch in our fork.
+
+### Custom Tasks
 
 Creating custom new tasks should be easy. You can contribute tasks using the regular gymnasium format. If your task has a trial/period structure, this [template](https://github.com/neurogym/neurogym/blob/main/docs/examples/template.py) provides the basic structure that we recommend a task to have:
 

--- a/README.md
+++ b/README.md
@@ -191,14 +191,14 @@ model = RecurrentPPO("MlpLstmPolicy", env_vec, policy_kwargs=policy_kwargs, verb
 model.learn(5000)
 ```
 
-> Note: This feature is part of an [open pull request](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib/pull/296) to the upstream repository and is currently under review by the maintainers. Until the pull request is merged, you can use this functionality by installing NeuroGym organization's fork of the repository. To do so, uninstall the original package and install from the custom branch:
->
-> ```bash
-> pip uninstall stable-baselines3-contrib -y
-> pip install git+https://github.com/neurogym/stable-baselines3-contrib.git@rnn_policy_addition
-> ```
->
-> This will install the version with vanilla RNN support from the `rnn_policy_addition` branch in our fork.
+**Note**: This feature is part of an [open pull request](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib/pull/296) to the upstream repository and is currently under review by the maintainers. Until the pull request is merged, you can use this functionality by installing NeuroGym organization's fork of the repository. To do so, uninstall the original package and install from the custom branch:
+
+```bash
+pip uninstall stable-baselines3-contrib -y
+pip install git+https://github.com/neurogym/stable-baselines3-contrib.git@rnn_policy_addition
+```
+
+This will install the version with vanilla RNN support from the `rnn_policy_addition` branch in our fork.
 
 ### Custom Tasks
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-## 1: Create a virtual environment
+## 1. Create a Virtual Environment
 
 Create and activate a virtual environment to install the current package, e.g. using
 [conda](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html) (please refer to their
@@ -12,7 +12,7 @@ conda create -n neurogym python=3.11 -y
 conda activate neurogym
 ```
 
-## 2: Install NeuroGym
+## 2. Install NeuroGym
 
 Install the latest stable release of `neurogym` using pip:
 
@@ -20,7 +20,7 @@ Install the latest stable release of `neurogym` using pip:
 pip install neurogym
 ```
 
-### 2a: Reinforcement Learning Support
+### 2.1 Reinforcement Learning Support
 
 NeuroGym includes optional reinforcement learning (RL) features via Stable-Baselines3.
 To install these, choose one of the two options below depending on your hardware setup:
@@ -43,7 +43,7 @@ pip install torch --index-url https://download.pytorch.org/whl/cpu
 pip install neurogym[rl]
 ```
 
-### 2b: Editable/Development Mode
+### 2.2 Editable/Development Mode
 
 To contribute to NeuroGym or run it from source with live code updates:
 
@@ -61,7 +61,7 @@ To include both RL and development tools (e.g., for testing, linting, documentat
 pip install -e .[rl,dev]
 ```
 
-## Step 3 (Optional): Psychopy installation
+## 3. Psychopy Installation (Optional)
 
 **NOTE**: psycohopy installation is currently not working
 

--- a/docs/neurogym.md
+++ b/docs/neurogym.md
@@ -42,7 +42,7 @@ Or directly pass the path:
 env = monitor.Monitor(env, config='path/to/config.toml')
 ```
 
-### 2. With Python class
+### 2. With Python Class
 
 ```python
 from neurogym import Config
@@ -53,7 +53,7 @@ config = Config(
 )
 ```
 
-### 3. With a dictionary
+### 3. With a Dictionary
 
 ```python
 from neurogym import Config
@@ -73,7 +73,30 @@ config = Config.model_validate(config_dict)
 NeuroGym is compatible with most packages that use gymnasium.
 In this [example](https://github.com/gyyang/neurogym/blob/master/examples/example_neurogym_rl.ipynb) jupyter notebook we show how to train a neural network with reinforcement learning algorithms using the [Stable-Baselines3](https://stable-baselines3.readthedocs.io/en/master/) toolbox.
 
-## Custom tasks
+### Vanilla RNN Support in RecurrentPPO
+
+We extended the [`RecurrentPPO`](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) implementation from `stable-baselines3-contrib` to support **vanilla RNNs** (`torch.nn.RNN`) in addition to LSTMs. This is particularly useful for neuroscience applications, where simpler recurrent architectures can be more biologically interpretable.
+
+You can enable vanilla RNNs by setting `recurrent_layer_type="rnn"` in the `policy_kwargs`:
+
+```python
+from sb3_contrib import RecurrentPPO
+
+policy_kwargs = {"recurrent_layer_type": "rnn"}  # "lstm" is the default
+model = RecurrentPPO("MlpLstmPolicy", env_vec, policy_kwargs=policy_kwargs, verbose=1)
+model.learn(5000)
+```
+
+> Note: This feature is part of an [open pull request](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib/pull/296) to the upstream repository and is currently under review by the maintainers. Until the pull request is merged, you can use this functionality by installing NeuroGym organization's fork of the repository. To do so, uninstall the original package and install from the custom branch:
+>
+> ```bash
+> pip uninstall stable-baselines3-contrib -y
+> pip install git+https://github.com/neurogym/stable-baselines3-contrib.git@rnn_policy_addition
+> ```
+>
+> This will install the version with vanilla RNN support from the `rnn_policy_addition` branch in our fork.
+
+## Custom Tasks
 
 Creating custom new tasks should be easy. You can contribute tasks using the regular gymnasium format. If your task has a trial/period structure, this [template](https://github.com/gyyang/neurogym/blob/master/examples/template.py) provides the basic structure that we recommend a task to have:
 

--- a/docs/neurogym.md
+++ b/docs/neurogym.md
@@ -87,14 +87,14 @@ model = RecurrentPPO("MlpLstmPolicy", env_vec, policy_kwargs=policy_kwargs, verb
 model.learn(5000)
 ```
 
-> Note: This feature is part of an [open pull request](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib/pull/296) to the upstream repository and is currently under review by the maintainers. Until the pull request is merged, you can use this functionality by installing NeuroGym organization's fork of the repository. To do so, uninstall the original package and install from the custom branch:
->
-> ```bash
-> pip uninstall stable-baselines3-contrib -y
-> pip install git+https://github.com/neurogym/stable-baselines3-contrib.git@rnn_policy_addition
-> ```
->
-> This will install the version with vanilla RNN support from the `rnn_policy_addition` branch in our fork.
+**Note**: This feature is part of an [open pull request](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib/pull/296) to the upstream repository and is currently under review by the maintainers. Until the pull request is merged, you can use this functionality by installing NeuroGym organization's fork of the repository. To do so, uninstall the original package and install from the custom branch:
+
+```bash
+pip uninstall stable-baselines3-contrib -y
+pip install git+https://github.com/neurogym/stable-baselines3-contrib.git@rnn_policy_addition
+```
+
+This will install the version with vanilla RNN support from the `rnn_policy_addition` branch in our fork.
 
 ## Custom Tasks
 


### PR DESCRIPTION
I’ve opened a [pull request](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib/pull/296) to the original `stable-baselines3-contrib` repository, which is currently pending review by the maintainers.

In the meantime, the feature is already available via our fork under the NeuroGym organization: https://github.com/neurogym/stable-baselines3-contrib (branch: `rnn_policy_addition`), and can be installed directly for immediate use.