### PR TITLE
fixed plotting in final cell of keras example notebook (#224)

### DIFF
--- a/docs/examples/supervised_learning_keras.ipynb
+++ b/docs/examples/supervised_learning_keras.ipynb
@@ -198,7 +198,11 @@
    },
    "outputs": [],
    "source": [
-    "# _ = ngym.utils.plotting.fig_(obs[0], action_pred[0], gt) # TODO: fix plotting"
+    "\n",
+    "obs = np.squeeze(obs, axis=1)  # remove the sequence dimension for plotting\n",
+    "action_pred = np.squeeze(action_pred, axis=1)  # remove the sequence dimension for plotting\n",
+    "\n",
+    "_ = ngym.utils.plotting.fig_(obs, action_pred, gt) # TODO: fix plotting"
    ]
   }
  ],
@@ -209,7 +213,7 @@
   },
   "hide_input": false,
   "kernelspec": {
-   "display_name": "ngym",
+   "display_name": "ngym_env",
    "language": "python",
    "name": "python3"
   },
@@ -223,7 +227,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.10"
+   "version": "3.12.5"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
This PR resolves an issue in the final cell of the Keras example notebook where the plotting function `fig_()` failed due to mismatched array shapes.

Changes made:
- Used `np.squeeze(..., axis=1)` on `obs` and `action_pred` to match the expected input shapes for `fig_()`.
- Verified that the plot renders correctly with actions and ground truth displayed.
- Left the rest of the notebook unchanged.
