### PR TITLE
fix: use `add_randn` on the stimuli periods only in `yang19` collection

### DIFF
--- a/neurogym/envs/collections/yang19.py
+++ b/neurogym/envs/collections/yang19.py
@@ -529,7 +529,21 @@ def _dm_kwargs():
 
 def dm1(**kwargs):
     env_kwargs = _dm_kwargs()
-    env_kwargs.update({"w_mod": (1, 1), "stim_mod": (True, False)})
+    if env_kwargs["delaycomparison"]:
+        timing = {
+            "fixation": ("uniform", (200, 500)),
+            "stim1": 500,
+            "delay": 1000,
+            "stim2": 500,
+            "decision": 200,
+        }
+    else:
+        timing = {
+            "fixation": ("uniform", (200, 500)),
+            "stimulus": ("choice", [200, 400, 600]),
+            "decision": 200,
+        }
+    env_kwargs.update({"timing": timing, "w_mod": (1, 1), "stim_mod": (True, False)})
     env_kwargs.update(kwargs)
     return _DMFamily(**env_kwargs)
 

--- a/neurogym/envs/collections/yang19.py
+++ b/neurogym/envs/collections/yang19.py
@@ -285,9 +285,11 @@ class _DMFamily(ngym.TrialEnv):
         self.add_ob(1, period="fixation", where="fixation")
         self.set_ob(0, "decision")
         if self.delaycomparison:
-            self.add_randn(0, self.sigma, ["stim1", "stim2"])
+            self.add_randn(0, self.sigma, period=["stim1", "stim2"], where="stimulus_mod1")
+            self.add_randn(0, self.sigma, period=["stim1", "stim2"], where="stimulus_mod2")
         else:
-            self.add_randn(0, self.sigma, ["stimulus"])
+            self.add_randn(0, self.sigma, period="stimulus", where="stimulus_mod1")
+            self.add_randn(0, self.sigma, period="stimulus", where="stimulus_mod2")
 
         coh1, coh2 = 0, 0
         if self.stim_mod1:
@@ -438,7 +440,7 @@ class _DelayMatch1DResponse(ngym.TrialEnv):
         self.set_ob(0, "decision", where="fixation")
         self.add_ob(stim_sample, "sample", where="stimulus")
         self.add_ob(stim_test, "test", where="stimulus")
-        self.add_randn(0, self.sigma, ["sample", "test"], where="stimulus")
+        self.add_randn(0, self.sigma, period=["sample", "test"], where="stimulus")
 
         if (ground_truth == "match" and self.matchgo) or (ground_truth == "non-match" and not self.matchgo):
             self.set_groundtruth(i_test_theta, period="decision", where="choice")


### PR DESCRIPTION
The original version was causing the noise to be added also to the fixation observation signal. It is now fixed, by being added specifically to the stimuli periods, on the stimuli signals only. 