### PR TITLE
Refactor: info module

### DIFF
--- a/docs/examples/demo.ipynb
+++ b/docs/examples/demo.ipynb
@@ -89,7 +89,8 @@
     "import warnings\n",
     "warnings.filterwarnings('ignore')\n",
     "import neurogym as ngym\n",
-    "from neurogym.utils import info, plotting\n",
+    "from neurogym import info\n",
+    "from neurogym.utils import plotting\n",
     "\n",
     "from IPython.display import clear_output\n",
     "clear_output()"

--- a/docs/examples/demo.ipynb
+++ b/docs/examples/demo.ipynb
@@ -104,7 +104,8 @@
     "from IPython.display import clear_output\n",
     "clear_output()\n",
     "\n",
-    "info.all_tasks()"
+    "info.show_all_tasks()\n",
+    "info.show_all_tags()"
    ]
   },
   {
@@ -167,7 +168,7 @@
    },
    "outputs": [],
    "source": [
-    "info.all_wrappers()"
+    "info.show_all_wrappers()"
    ]
   },
   {

--- a/docs/examples/demo.ipynb
+++ b/docs/examples/demo.ipynb
@@ -188,7 +188,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As seen in the info of the Go-Nogo task above, each environment has a number of tags associated to it.\n",
+    "As seen in the info of the Go-Nogo task above, each environment has a number of tags associated with it.\n",
     "\n",
     "The complete list of tags is as follows:\n"
    ]
@@ -206,7 +206,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can specifically list the environments associated to a given tag\n"
+    "You can specifically list the environments associated with a given tag\n"
    ]
   },
   {

--- a/docs/examples/demo.ipynb
+++ b/docs/examples/demo.ipynb
@@ -75,6 +75,28 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Import libraries\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import warnings\n",
+    "warnings.filterwarnings('ignore')\n",
+    "import neurogym as ngym\n",
+    "from neurogym.utils import info, plotting\n",
+    "\n",
+    "from IPython.display import clear_output\n",
+    "clear_output()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",
     "id": "ZllQKETBVXNM"
@@ -97,15 +119,7 @@
    },
    "outputs": [],
    "source": [
-    "import warnings\n",
-    "warnings.filterwarnings('ignore')\n",
-    "import neurogym as ngym\n",
-    "from neurogym.utils import info, plotting\n",
-    "from IPython.display import clear_output\n",
-    "clear_output()\n",
-    "\n",
-    "info.show_all_tasks()\n",
-    "info.show_all_tags()"
+    "info.show_all_tasks()"
    ]
   },
   {
@@ -116,6 +130,15 @@
    },
    "source": [
     "### Visualize a single task\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "info.show_info(\"GoNogo-v0\")"
    ]
   },
   {
@@ -142,6 +165,56 @@
     "    ob_traces=['Fixation cue', 'NoGo', 'Go'],\n",
     "    # fig_kwargs={'figsize': (12, 12)}\n",
     "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "info.show_info(env)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Explore tags\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As seen in the info of the Go-Nogo task above, each environment has a number of tags associated to it.\n",
+    "\n",
+    "The complete list of tags is as follows:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "info.show_all_tags()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can specifically list the environments associated to a given tag\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "info.show_all_tasks(tag=\"timing\")"
    ]
   },
   {
@@ -185,7 +258,7 @@
    },
    "outputs": [],
    "source": [
-    "info.info_wrapper('TrialHistoryV2-v0')"
+    "info.show_info('Monitor-v0')\n"
    ]
   },
   {
@@ -215,8 +288,6 @@
    },
    "outputs": [],
    "source": [
-    "import warnings\n",
-    "warnings.filterwarnings('ignore')\n",
     "import numpy as np\n",
     "from neurogym.wrappers import Monitor, TrialHistoryV2\n",
     "from stable_baselines3.common.vec_env import DummyVecEnv\n",

--- a/neurogym/__init__.py
+++ b/neurogym/__init__.py
@@ -1,5 +1,5 @@
-from neurogym.envs.registration import make, register
-from neurogym.utils import spaces
-from neurogym.utils.data import Dataset
+from .envs.registration import make, register
+from .utils import info, spaces
+from .utils.data import Dataset
 
 __version__ = "2.1.0"

--- a/neurogym/core.py
+++ b/neurogym/core.py
@@ -24,9 +24,9 @@ def env_string(env, short=False):
     metadata = env.metadata
     docstring = env.__doc__
     string += f"### {type(env).__name__}\n"
-    paper_name = metadata.get("paper_name", None) or "Missing paper name"
+    paper_name = metadata.get("paper_name") or "Missing paper name"
     paper_name = _clean_string(paper_name)
-    paper_link = metadata.get("paper_link", None)
+    paper_link = metadata.get("paper_link")
     string += f"Doc: {docstring}\n"
     string += "Reference paper \n"
     if paper_link is None:

--- a/neurogym/envs/registration.py
+++ b/neurogym/envs/registration.py
@@ -120,27 +120,6 @@ def all_envs(
     return new_env_list
 
 
-def all_tags():
-    return [
-        "confidence",
-        "context dependent",
-        "continuous action space",
-        "delayed response",
-        "go-no-go",
-        "motor",
-        "multidimensional action space",
-        "n-alternative",
-        "perceptual",
-        "reaction time",
-        "steps action space",
-        "supervised",
-        "timing",
-        "two-alternative",
-        "value-based",
-        "working memory",
-    ]
-
-
 def make(id_: str, **kwargs) -> gym.Env:
     """Creates an environment previously registered with :meth:`ngym.register`.
 
@@ -165,3 +144,14 @@ def register(id_: str, **kwargs) -> None:
 
 for env_id, entry_point in ALL_EXTENDED_ENVS.items():
     register(id_=env_id, entry_point=entry_point)
+
+
+def all_tags() -> list[str]:
+    """Script to get all tags."""
+    envs = all_envs()
+    tags = []
+    for env_name in sorted(envs):
+        env = make(env_name)
+        metadata = env.metadata
+        tags += metadata.get("tags", [])
+    return list(set(tags))

--- a/neurogym/envs/registration.py
+++ b/neurogym/envs/registration.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import gymnasium as gym
 
 from neurogym.envs.collections import get_collection
+from neurogym.utils.logging import logger
 
 _HAVE_PSYCHOPY = find_spec("psychopy") is not None  # check if psychopy is installed
 _INCLUDE_CONTRIB = False  # FIXME: these are currently not passing tests
@@ -117,6 +118,9 @@ def all_envs(
         env_tag = imported.metadata.get("tags", [])
         if tag in env_tag:
             new_env_list.append(env)
+    if not new_env_list:
+        logger.warning(f"No environments found with tag '{tag}'.")
+
     return new_env_list
 
 

--- a/neurogym/envs/registration.py
+++ b/neurogym/envs/registration.py
@@ -151,7 +151,7 @@ for env_id, entry_point in ALL_EXTENDED_ENVS.items():
 
 
 def all_tags() -> list[str]:
-    """Script to get all tags."""
+    """Discover and return all tags associated to any environment."""
     envs = all_envs()
     tags = []
     for env_name in sorted(envs):

--- a/neurogym/utils/info.py
+++ b/neurogym/utils/info.py
@@ -9,13 +9,13 @@ from neurogym.wrappers import ALL_WRAPPERS, all_wrappers
 
 
 def show_all_tasks() -> None:
-    logger.info("Available tasks:")
+    logger.info("Available tasks:", color="green")
     for task in sorted(ALL_ENVS):
         logger.info(task)
 
 
 def show_all_wrappers() -> None:
-    logger.info("Available wrappers:")
+    logger.info("Available wrappers:", color="green")
     for wrapper in all_wrappers():
         logger.info(wrapper)
 
@@ -79,6 +79,6 @@ def info_wrapper(wrapper=None, show_code=False):
 
 
 def show_all_tags():
-    logger.info("Available tags:")
+    logger.info("Available tags:", color="green")
     for tag in all_tags():
         logger.info(tag)

--- a/neurogym/utils/info.py
+++ b/neurogym/utils/info.py
@@ -3,18 +3,20 @@
 import inspect
 
 from neurogym.core import METADATA_DEF_KEYS, env_string
-from neurogym.envs.registration import ALL_ENVS, all_envs, make
+from neurogym.envs.registration import ALL_ENVS, all_tags, make
 from neurogym.utils.logging import logger
-from neurogym.wrappers import ALL_WRAPPERS
+from neurogym.wrappers import ALL_WRAPPERS, all_wrappers
 
 
-def all_tasks() -> None:
+def show_all_tasks() -> None:
+    logger.info("Available tasks:")
     for task in sorted(ALL_ENVS):
         logger.info(task)
 
 
-def all_wrappers() -> None:
-    for wrapper in sorted(ALL_WRAPPERS):
+def show_all_wrappers() -> None:
+    logger.info("Available wrappers:")
+    for wrapper in all_wrappers():
         logger.info(wrapper)
 
 
@@ -76,21 +78,7 @@ def info_wrapper(wrapper=None, show_code=False):
     return string
 
 
-def all_tags(verbose=0):
-    """Script to get all tags."""
-    envs = all_envs()
-    tags = []
-    for env_name in sorted(envs):
-        try:
-            env = make(env_name)
-            metadata = env.metadata
-            tags += metadata.get("tags", [])
-        except BaseException as e:  # noqa: BLE001, PERF203 # FIXME: unclear which error is expected here.
-            logger.error(f"Failure in {env_name}")
-            logger.error(e)
-    tags = set(tags)
-    if verbose:
-        logger.info("\nTAGS:\n")
-        for tag in tags:
-            logger.info(tag)
-    return tags
+def show_all_tags():
+    logger.info("Available tags:")
+    for tag in all_tags():
+        logger.info(tag)

--- a/neurogym/utils/info.py
+++ b/neurogym/utils/info.py
@@ -79,11 +79,11 @@ def _wrap_info(wrapper: str) -> None:
     if not isinstance(metadata, dict):
         metadata = {}
 
-    wrapper_description = metadata.get("description", None) or "Missing description"
+    wrapper_description = metadata.get("description") or "Missing description"
     logger.info(f"Logic: {wrapper_description}")
 
-    paper_name = metadata.get("paper_name", None)
-    paper_link = metadata.get("paper_link", None)
+    paper_name = metadata.get("paper_name")
+    paper_link = metadata.get("paper_link")
     if paper_name is not None:
         reference = "Reference paper: "
         if paper_link is None:

--- a/neurogym/utils/info.py
+++ b/neurogym/utils/info.py
@@ -3,21 +3,38 @@
 import inspect
 
 from neurogym.core import METADATA_DEF_KEYS, env_string
-from neurogym.envs.registration import ALL_ENVS, all_tags, make
+from neurogym.envs.registration import ALL_ENVS, all_envs, all_tags, make
 from neurogym.utils.logging import logger
 from neurogym.wrappers import ALL_WRAPPERS, all_wrappers
 
 
-def show_all_tasks() -> None:
-    logger.info("Available tasks:", color="green")
-    for task in sorted(ALL_ENVS):
+def show_all_tasks(tag: str | None = None) -> None:
+    """Show all available tasks in neurogym.
+
+    Args:
+        tag: If provided, only show tasks with this tag.
+    """
+    if not tag:
+        logger.info("Available tasks:", color="green")
+    else:
+        logger.info(f"Available tasks with tag '{tag}':", color="green")
+
+    for task in all_envs(tag=tag):
         logger.info(task)
 
 
 def show_all_wrappers() -> None:
+    """Show all available wrappers in neurogym."""
     logger.info("Available wrappers:", color="green")
     for wrapper in all_wrappers():
         logger.info(wrapper)
+
+
+def show_all_tags():
+    """Show all available tags in neurogym."""
+    logger.info("Available tags:", color="green")
+    for tag in all_tags():
+        logger.info(tag)
 
 
 def info(env=None, show_code=False):
@@ -76,9 +93,3 @@ def info_wrapper(wrapper=None, show_code=False):
         string += lines + "\n\n"
 
     return string
-
-
-def show_all_tags():
-    logger.info("Available tags:", color="green")
-    for tag in all_tags():
-        logger.info(tag)

--- a/neurogym/utils/info.py
+++ b/neurogym/utils/info.py
@@ -63,11 +63,13 @@ def show_info(obj_: str | gym.Env) -> None:
 
 
 def _env_info(env: gym.Env) -> None:
+    """Show information about an environment."""
     env = env.unwrapped  # remove extra wrappers (make can add a OrderEnforcer wrapper)
     logger.info("Info for environment:" + env_string(env)[3:])
 
 
 def _wrap_info(wrapper: str) -> None:
+    """Show information about a wrapper."""
     logger.info(f"Info for wrapper: {wrapper}")
 
     wrapp_ref = ALL_WRAPPERS[wrapper]

--- a/neurogym/utils/logging.py
+++ b/neurogym/utils/logging.py
@@ -1,10 +1,24 @@
+from __future__ import annotations
+
 import sys
+from typing import TYPE_CHECKING
 
 from loguru import logger
 from loguru._colorizer import AnsiParser
 
+if TYPE_CHECKING:
+    from loguru import Record
 
-def custom_format(record):
+
+def _custom_format(record: Record) -> str:
+    """Put together a context-aware custom format string.
+
+    Args:
+        record: The log record to process.
+
+    Returns:
+        A  Loguru formatting string.
+    """
     message = record["message"]
 
     # give custom color to log message
@@ -25,6 +39,6 @@ def custom_format(record):
 logger.remove()
 logger.add(
     sys.stderr,
-    format=custom_format,
+    format=_custom_format,
     level="INFO",
 )

--- a/neurogym/utils/logging.py
+++ b/neurogym/utils/logging.py
@@ -1,10 +1,30 @@
 import sys
 
 from loguru import logger
+from loguru._colorizer import AnsiParser
+
+
+def custom_format(record):
+    message = record["message"]
+
+    # give custom color to log message
+    color = record["extra"].get("color", "level")
+    if color not in list(AnsiParser._foreground) + list(AnsiParser._background):  # noqa: SLF001
+        color = "level"
+    message = f"<{color}>{message}</{color}>"
+
+    # give custom style (bold, etc) to log message
+    style = record["extra"].get("style", "level")
+    if style not in AnsiParser._style:  # noqa: SLF001
+        style = "level"
+    message = f"<{style}>{message}</{style}>"
+
+    return f"<magenta>Neurogym</magenta> | <cyan>{record['time']:YYYY-MM-DD@HH:mm:ss}</cyan> | {message}\n"
+
 
 logger.remove()
 logger.add(
     sys.stderr,
-    format="<magenta>Neurogym</magenta> | <cyan>{time:YYYY-MM-DD@HH:mm:ss}</cyan> | <level>{message}</level>",
+    format=custom_format,
     level="INFO",
 )

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -19,7 +19,7 @@ ENVS = all_envs(psychopy=_HAVE_PSYCHOPY, contrib=True, collections=True)
 ENVS_NOPSYCHOPY = all_envs(psychopy=False, contrib=True, collections=True)
 
 
-def _test_run(env, num_steps=100, verbose=False):
+def _test_run(env, num_steps=100):
     """Test if one environment can at least be run."""
     if isinstance(env, str):
         env = make(env)
@@ -35,24 +35,19 @@ def _test_run(env, num_steps=100, verbose=False):
             env.reset()
 
     tags = env.metadata.get("tags", [])
-    for t in tags:
-        if t not in all_tags():
-            logger.warning(f"env has tag {t} not in all_tags")
-
-    if verbose:
-        logger.info(env)
+    assert all(t in all_tags() for t in tags)
 
     return env
 
 
-def test_run_all(verbose_success=False):
+def test_run_all():
     """Test if all environments can at least be run."""
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", message=".*get variables from other wrappers is deprecated*")
         warnings.filterwarnings("ignore", message=".*The environment creator metadata doesn't include `render_modes`*")
         try:
             for env_name in ENVS:
-                _test_run(env_name, verbose=verbose_success)
+                _test_run(env_name)
         except:
             logger.error(f"Failure at running env: {env_name}")
             raise


### PR DESCRIPTION
- `registration.all_tags` was not up to date. The code in the info module however reads all tags rather than pre-defining them, so I moved that over.
- the info module is now truly focussed on printing stuff, and I refactored the way that happens and the name of the functions doing so.
  - once #243 is merged, we should add neurogym.utils.info to the top level init
- allow for non-default color/font-style logs
- update demo notebook to reflect this.


blocked by #243 